### PR TITLE
refactor: switch inline comments to MCP tool

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -43,50 +43,6 @@ jobs:
                 }
               }"
           done
-      - name: Resolve duplicate Copilot review threads
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Copilot re-posts findings on every push. Keep only the newest
-          # unresolved thread per path+line, resolve older duplicates.
-          # shellcheck disable=SC2016
-          gh api graphql \
-            -f owner="$REPO_OWNER" \
-            -f name="$REPO_NAME" \
-            -F number="$PR_NUMBER" \
-            -f query='query($owner: String!, $name: String!, $number: Int!) {
-              repository(owner: $owner, name: $name) {
-                pullRequest(number: $number) {
-                  reviewThreads(first: 100) {
-                    nodes {
-                      id
-                      isResolved
-                      comments(first: 1) {
-                        nodes { author { login } path line createdAt }
-                      }
-                    }
-                  }
-                }
-              }
-            }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.isResolved == false and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")
-              | {id, path: .comments.nodes[0].path, line: .comments.nodes[0].line, createdAt: .comments.nodes[0].createdAt}]
-              | group_by(.path + ":" + (.line | tostring))
-              | .[]
-              | sort_by(.createdAt)
-              | .[:-1]
-              | .[].id' | while read -r thread_id; do
-              echo "Resolving duplicate Copilot thread $thread_id"
-              gh api graphql -f query="
-                mutation {
-                  resolveReviewThread(input: {threadId: \"$thread_id\"}) {
-                    thread { isResolved }
-                  }
-                }"
-          done
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5  # v1.0.71

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -42,8 +42,7 @@ flowchart TD
   A(PR opened, pushed, or ready) --> B(Author is bot or fork)
   B -->|Yes| Z(Workflow skipped)
   B -->|No| C(Checkout repository)
-  C --> C2(Shell: Minimize outdated Claude comments)
-  C2 --> D(Shell: Resolve duplicate Copilot threads)
+  C --> D(Shell: Minimize outdated Claude comments)
   D --> E(Step 1: Read CLAUDE.md and project conventions)
   E --> F(Step 2: Get PR diff + fetch previous comments and threads)
   F --> G(Step 3: Process previous claude bot review threads)
@@ -52,14 +51,9 @@ flowchart TD
   I --> J(Step 6: Post PR summary comment)
 ```
 
-### Pre-steps: Cleanup (shell)
+### Pre-step: Minimize Outdated Comments (shell)
 
-Two dedicated shell steps run **before** the Claude review:
-
-1. **Minimize outdated Claude comments** — finds all previous `claude[bot]` PR comments matching summary or tracking patterns and minimizes them as outdated
-2. **Resolve duplicate Copilot threads** — Copilot re-posts the same findings on every push. This step keeps only the newest unresolved thread per path+line and resolves older duplicates
-
-These are shell scripts, not Claude instructions, so they always run regardless of what Claude decides to do.
+A dedicated shell step (not part of the Claude prompt) runs **before** the review. It finds all previous PR comments authored by `claude[bot]` that match summary or tracking patterns and minimizes them as outdated. This is a shell script, not a Claude instruction, so it always runs regardless of what Claude decides to do.
 
 ### Step 1: Learn Project Context
 
@@ -166,7 +160,7 @@ When a developer pushes fixes after a review:
 ```mermaid
 flowchart TD
   A(Developer pushes fix) --> B(Workflow triggers on synchronize)
-  B --> C(Shell: Minimize old Claude comments + resolve duplicate Copilot threads)
+  B --> C(Shell: Minimize old Claude comments)
   C --> D(Get full PR diff + previous comments)
   D --> E{Previous Claude issue status}
   E -->|Fixed| F(Resolve thread + minimize as outdated)


### PR DESCRIPTION
## Summary
- Replace manual `gh api` JSON piping in Step 5 with built-in `mcp__github_inline_comment__create_inline_comment` MCP tool
- Remove unused `COMMIT_SHA` prompt variable (MCP auto-resolves to PR HEAD)
- Add MCP tool to settings allow list
- Keep `Bash(gh api:*)` for thread resolution, minimization, and Copilot triage

## Test plan
- [ ] Claude review workflow triggers on this PR
- [ ] Claude posts inline comments using the MCP tool instead of `gh api`
- [ ] Thread resolution and Copilot triage still work via `gh api`

Part of #33