### PR TITLE
fix: set fetch-depth: 0 to prevent claude-code-action git fetch failure

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0  # Full history — avoids claude-code-action needing its own git fetch with cleared credentials
           persist-credentials: false  # Security: don't persist credentials
       - name: Minimize outdated Claude comments
         env:


### PR DESCRIPTION
## Problem

Despite #40 (passing `github_token`), `claude-code-action` still fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
Command failed: git fetch origin --depth=20 <branch>
```

The `github_token` input helps for API calls but not for the action's internal `git fetch` which runs before `configureGitAuth()`.

## Root cause

`fetch-depth: 1` only fetches 1 commit of the merge ref. The action then needs to fetch the PR branch with depth 20, but `persist-credentials: false` has already cleared the credentials.

## Fix

Set `fetch-depth: 0` — full history is fetched during checkout (with credentials), so the action doesn't need its own fetch. `persist-credentials: false` is preserved (no zizmor issues).

Closes #41