### PR TITLE
feat: add reusable-claude.yml for @claude mention workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,23 @@
+---
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+permissions: {}
+jobs:
+  claude:
+    uses: ./.github/workflows/reusable-claude.yml
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -1,0 +1,39 @@
+---
+name: Claude Code (reusable)
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+permissions: {}
+jobs:
+  claude:
+    # Run Claude only when a human (not renovate) mentions @claude in an
+    # issue, PR comment, review, or review comment. The caller workflow
+    # subscribes to all four events; this job filters them.
+    if: |
+      github.actor != 'renovate[bot]' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write  # Required for claude-code-action OIDC auth
+      actions: read  # Required for Claude to read CI results on PRs
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: true  # Required: claude-code-action needs git credentials
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1.0.88
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -8,11 +8,17 @@ on:
 permissions: {}
 jobs:
   claude:
-    # Run Claude only when a human (not renovate) mentions @claude in an
-    # issue, PR comment, review, or review comment. The caller workflow
-    # subscribes to all four events; this job filters them.
+    # Run Claude only when a human mentions @claude in an issue, PR
+    # comment, review, or review comment. The caller workflow subscribes
+    # to all four events; this job filters them.
+    #
+    # Bots are excluded via `sender.type != 'Bot'` rather than matching
+    # actor strings — some bot reviewers (e.g. Copilot) don't have a
+    # `[bot]` suffix on their login, and `claude-code-action` with OAuth
+    # auth fails with 401 when the triggering actor lacks write access
+    # (see CLAUDE.md > Known Limitation: pull_request_review + OAuth).
     if: |
-      github.actor != 'renovate[bot]' && (
+      github.event.sender.type != 'Bot' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This repository contains **GitHub Actions workflows (reusable and caller/CI)**. 
 - Workflows must set `permissions: {}` at the top level and grant only required permissions at the job level
 - Checkout steps must include `persist-credentials: false` — exceptions:
   - `reusable-claude-code-review.yml` — `claude-code-action` needs git credentials for PR branch fetch
+  - `reusable-claude.yml` — `claude-code-action` needs git credentials to operate on the PR branch
   - `reusable-actionlint.yml` — reviewdog falls back to `git fetch` for diff fetching on private repos
 - Reusable workflows accept secrets via `workflow_call` — never hardcode secrets or tokens
 - Use `${{ github.repository_owner }}` instead of hardcoding the org name to keep workflows portable
@@ -28,6 +29,7 @@ This repository contains **GitHub Actions workflows (reusable and caller/CI)**. 
 ## Review Architecture
 
 - Claude Code Review (`reusable-claude-code-review.yml`) runs on `pull_request` events — reviews code and triages previous review threads (from Claude, bot reviewers, and human reviewers)
+- Claude Code (`reusable-claude.yml`) runs on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events — invokes `claude-code-action` when a human mentions `@claude` (renovate is skipped)
 
 ### Known Limitation: `pull_request_review` trigger and OAuth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This repository contains **GitHub Actions workflows (reusable and caller/CI)**. 
 ## Review Architecture
 
 - Claude Code Review (`reusable-claude-code-review.yml`) runs on `pull_request` events — reviews code and triages previous review threads (from Claude, bot reviewers, and human reviewers)
-- Claude Code (`reusable-claude.yml`) runs on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events — invokes `claude-code-action` when a human mentions `@claude` (renovate is skipped)
+- Claude Code (`reusable-claude.yml`) runs on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events — invokes `claude-code-action` when a human mentions `@claude` (all bot actors excluded via `sender.type != 'Bot'`)
 
 ### Known Limitation: `pull_request_review` trigger and OAuth
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains **GitHub Actions workflows (reusable and caller/CI)**. 
 | Workflow | Description |
 |----------|-------------|
 | `reusable-actionlint.yml` | GitHub Actions workflow validation using actionlint |
+| `reusable-claude.yml` | On-demand Claude Code assistant triggered by `@claude` mentions in issues, PRs, and reviews |
 | `reusable-claude-code-review.yml` | AI-powered code review using Claude Code |
 | `reusable-add-issue-to-project.yml` | Automatically add new issues to a GitHub project board |
 | `reusable-pr.yml` | PR checks with conventional commit validation |
@@ -32,6 +33,31 @@ Call a reusable workflow from your repository:
 jobs:
   claude-review:
     uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude-code-review.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+```yaml
+# @claude mention handler — triggered from issues, PR comments, and reviews
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+permissions: {}
+jobs:
+  claude:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude.yml@main
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -24,7 +24,7 @@ The caller subscribes to four events and the reusable job filters them:
 
 A run is only dispatched when **all** of the following hold:
 
-- The actor is not `renovate[bot]`
+- The triggering actor is not a bot (`sender.type != 'Bot'`)
 - The event payload contains the string `@claude` in the relevant field (comment body, review body, issue body, or issue title)
 
 ## Permissions

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -1,0 +1,87 @@
+# Claude Code Workflow
+
+On-demand Claude Code assistant triggered by `@claude` mentions, implemented as a reusable workflow.
+
+## Architecture
+
+`reusable-claude.yml` wraps [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action). Any repo in the org can call it via a thin caller workflow. This repo dogfoods it via `claude.yml`.
+
+```
+calling-repo/.github/workflows/claude.yml
+  └─ uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude.yml@main
+```
+
+## Trigger Conditions
+
+The caller subscribes to four events and the reusable job filters them:
+
+| Event | When it fires |
+|-------|---------------|
+| `issue_comment` (created) | Someone comments on an issue or PR |
+| `pull_request_review_comment` (created) | Someone comments on a PR diff line |
+| `pull_request_review` (submitted) | Someone submits a PR review |
+| `issues` (opened, assigned) | An issue is opened or assigned |
+
+A run is only dispatched when **all** of the following hold:
+
+- The actor is not `renovate[bot]`
+- The event payload contains the string `@claude` in the relevant field (comment body, review body, issue body, or issue title)
+
+## Permissions
+
+The caller must grant the following at the job level:
+
+| Permission | Level | Purpose |
+|------------|-------|---------|
+| `contents` | read | Read repository files |
+| `pull-requests` | read | Read PR metadata |
+| `issues` | read | Read issue metadata |
+| `id-token` | write | OIDC authentication for `claude-code-action` |
+| `actions` | read | Let Claude read CI results on PRs |
+
+The reusable workflow itself declares the same permissions at the job level. Top-level permissions are `{}`.
+
+## Usage
+
+```yaml
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+permissions: {}
+jobs:
+  claude:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude.yml@main
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+## Configuration
+
+- **Reusable workflow**: `reusable-claude.yml`
+- **Secret required**: `CLAUDE_CODE_OAUTH_TOKEN`
+- **Timeout**: 30 minutes per run
+- **Checkout depth**: `fetch-depth: 1` (shallow; the action fetches more if it needs to)
+
+## Relationship to `reusable-claude-code-review.yml`
+
+The two workflows serve different purposes and should not be confused:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `reusable-claude-code-review.yml` | `pull_request` events | Automated code review on every PR push |
+| `reusable-claude.yml` | `@claude` mentions in issues, comments, and reviews | On-demand assistant for ad-hoc tasks |
+
+Both use `anthropics/claude-code-action` and the same `CLAUDE_CODE_OAUTH_TOKEN` secret, but they run independently.

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -3,8 +3,15 @@ rules:
   # Secrets are protected by GitHub's fork PR approval requirement,
   # which prevents untrusted workflows from accessing secrets without explicit approval.
   secrets-outside-env:
-    ignore: [claude-code-review.yml, reusable-claude-code-review.yml]
+    ignore:
+      - claude-code-review.yml
+      - reusable-claude-code-review.yml
+      - claude.yml
+      - reusable-claude.yml
   # claude-code-action and reviewdog need git credentials for PR branch/diff fetch.
   # Risk is minimal: runner is ephemeral and token expires with the workflow.
   artipacked:
-    ignore: [reusable-claude-code-review.yml, reusable-actionlint.yml]
+    ignore:
+      - reusable-claude-code-review.yml
+      - reusable-actionlint.yml
+      - reusable-claude.yml


### PR DESCRIPTION
## Summary

- Adds `reusable-claude.yml` — a reusable wrapper around `anthropics/claude-code-action` that fires on `@claude` mentions in issues, PR comments, and reviews (skipping `renovate[bot]`).
- Adds a local `claude.yml` caller so this repo dogfoods the new reusable.
- Documents the workflow in `docs/claude.md`, `README.md`, and `CLAUDE.md` (including the `persist-credentials: true` exception, which matches the existing exception for `reusable-claude-code-review.yml`).
- Extends `zizmor.yml` to ignore `secrets-outside-env` + `artipacked` for the new files (same treatment as the existing review workflow).

Closes #62

## Test plan

- [x] Pre-commit hooks pass locally (`actionlint`, `zizmor`, `detect-secrets`, etc.)
- [ ] Repo CI passes (reusable-actionlint caller + reusable-pr caller)
- [ ] Claude code review on this PR passes

## Follow-up

After this merges, open migration issues in the two consumer repos that currently carry a standalone `claude.yml`:
- `SchweizerischeBundesbahnen/python-sbb-polarion`
- `SchweizerischeBundesbahnen/open-source-polarion-python-repo-template`