### PR TITLE
feat: harden reusable-claude.yml and align model/turns across both workflows

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -245,4 +245,4 @@ jobs:
                 ]
               }
             }
-          claude_args: --max-turns 30
+          claude_args: --max-turns 30 --model opus

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -43,3 +43,7 @@ jobs:
         uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          additional_permissions: |
+            actions: read
+          claude_args: --max-turns 30 --model opus

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -73,6 +73,10 @@ jobs:
 - **Reusable workflow**: `reusable-claude.yml`
 - **Secret required**: `CLAUDE_CODE_OAUTH_TOKEN`
 - **Timeout**: 30 minutes per run
+- **Max turns**: 30 (cost/runaway guard; matches `reusable-claude-code-review.yml`)
+- **Model**: `opus` (short alias — auto-upgrades to latest Opus generation)
+- **Progress tracking**: `track_progress: true` — posts a sticky "Claude is working..." comment with live checklist
+- **CI access**: `additional_permissions: actions: read` — enables `mcp__github_ci__*` MCP tools so Claude can read CI logs when asked "@claude why did this fail?"
 - **Checkout depth**: `fetch-depth: 1` (shallow; the action fetches more if it needs to)
 
 ## Relationship to `reusable-claude-code-review.yml`


### PR DESCRIPTION
## Summary

- **`reusable-claude.yml`**: adds `track_progress: true`, `additional_permissions: actions: read`, `--max-turns 30`, `--model opus`
- **`reusable-claude-code-review.yml`**: adds `--model opus` (already had `--max-turns 30`)
- **`docs/claude-code.md`**: documents new configuration

Both workflows now use `--model opus` (short alias, auto-upgrades to latest Opus generation) and `--max-turns 30`.

Closes #64

## Test plan

- [x] Pre-commit hooks pass (actionlint, zizmor, detect-secrets)
- [ ] CI passes (actionlint, PR checks, claude-code-review)
- [ ] Next `@claude` mention on a PR in this repo shows progress tracking and can read CI logs