### PR TITLE
feat: use formal PR review verdict and add extra_focus input

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -2,6 +2,12 @@
 name: Claude Code Review (reusable)
 on:
   workflow_call:
+    inputs:
+      extra_focus:
+        description: Optional extra review focus (e.g. "check backward compatibility of the API changes")
+        required: false
+        type: string
+        default: ""
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -122,6 +128,7 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            EXTRA REVIEW FOCUS: ${{ inputs.extra_focus }}
 
             The PR branch is already checked out. Use Read/Grep/Glob to
             search the codebase for context.
@@ -200,7 +207,14 @@ jobs:
             collapsible `<details>` block with extended reasoning.
             Emojis: 🔴 bug, 🟠 security, 🟡 risky pattern, 🔵 CLAUDE.md violation.
 
-            7. Post a PR summary via `gh pr comment` with this structure:
+            7. Submit a formal PR review via `gh pr review` with this structure.
+            Choose the review event based on findings:
+            - No issues found → `--event COMMENT`
+            - Issues found with confidence >= 80 → `--event REQUEST_CHANGES`
+            - Issues found with confidence < 80 → `--event COMMENT`
+            - NEVER use `--event APPROVE` (auto-approve from a bot can bypass
+              human review gates in branch protection rules)
+            The review body should contain:
             - `## Claude Code Review Summary` (or `## ✅ No issues found` /
               `## ℹ️ No new issues found — N bot reviewer finding(s) and M human reviewer finding(s) acknowledged`)
             - `<details><summary><h3>Confidence Score: X/5</h3></summary>`
@@ -215,6 +229,7 @@ jobs:
               (OMIT if `human_threads` is empty)
             - `<details><summary><h3>Important Files Changed</h3></summary>`
               with markdown table (filename | overview)
+            Example: `gh pr review ${{ github.event.pull_request.number }} --event COMMENT --body "review body here"`
             CRITICAL: Use ONLY the pre-classified categories from
             `/tmp/classified-threads.json` for the summary sections. Do NOT
             re-classify threads or attribute threads to different authors.
@@ -231,14 +246,14 @@ jobs:
             - Ignore: unchanged code, style/formatting, optional improvements,
               dependency versions. Do NOT run build tools or provide praise.
             - Every API call is permanent. Do NOT post test or placeholder comments.
-            - Only post GitHub comments — don't submit review text as messages.
+            - Only post GitHub review submissions — don't submit review text as messages.
           settings: |
             {
               "permissions": {
                 "allow": [
                   "Read", "Grep", "Glob", "BatchTool",
                   "mcp__github_inline_comment__create_inline_comment",
-                  "Bash(gh pr comment:*)",
+                  "Bash(gh pr review:*)",
                   "Bash(gh pr diff:*)",
                   "Bash(gh pr view:*)",
                   "Bash(gh api:*)"

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -210,8 +210,7 @@ jobs:
             7. Submit a formal PR review via `gh pr review` with this structure.
             Choose the review event based on findings:
             - No issues found → `--event COMMENT`
-            - Issues found with confidence >= 80 → `--event REQUEST_CHANGES`
-            - Issues found with confidence < 80 → `--event COMMENT`
+            - Issues found (confidence >= 80) → `--event REQUEST_CHANGES`
             - NEVER use `--event APPROVE` (auto-approve from a bot can bypass
               human review gates in branch protection rules)
             The review body should contain:

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -172,8 +172,7 @@ A formal GitHub PR review is submitted via `gh pr review`. This shows in the PR'
 | Scenario | Event |
 |----------|-------|
 | No issues found | `COMMENT` |
-| Issues found, confidence >= 80 | `REQUEST_CHANGES` |
-| Issues found, confidence < 80 | `COMMENT` |
+| Issues found (confidence >= 80) | `REQUEST_CHANGES` |
 
 Claude **never** uses `APPROVE` — auto-approving from a bot can silently satisfy branch protection rules, bypassing human review gates.
 
@@ -230,7 +229,7 @@ The caller workflow must grant these permissions:
 |------------|-------|---------|
 | `contents` | read | Read repository files |
 | `pull-requests` | write | Post review comments |
-| `issues` | write | Required for `gh pr review` |
+| `issues` | write | Manage PR comments/threads and minimize outdated comments via API |
 | `id-token` | write | OIDC authentication |
 
 Claude's tool access is restricted to:

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -163,9 +163,21 @@ Detailed explanation of the issue, proof, impact, and fix.
 | :yellow_circle: | Warning | Likely bug or risky pattern |
 | :large_blue_circle: | Convention | CLAUDE.md violation |
 
-### Step 7: Post PR Summary Comment
+### Step 7: Submit PR Review
 
-A summary comment is posted on the PR. The heading varies based on findings:
+A formal GitHub PR review is submitted via `gh pr review`. This shows in the PR's "Reviews" sidebar (not buried in the comment timeline) and signals a clear verdict.
+
+**Review verdict:**
+
+| Scenario | Event |
+|----------|-------|
+| No issues found | `COMMENT` |
+| Issues found, confidence >= 80 | `REQUEST_CHANGES` |
+| Issues found, confidence < 80 | `COMMENT` |
+
+Claude **never** uses `APPROVE` — auto-approving from a bot can silently satisfy branch protection rules, bypassing human review gates.
+
+The review body heading varies based on findings:
 
 | Scenario | Heading |
 |----------|---------|
@@ -218,14 +230,14 @@ The caller workflow must grant these permissions:
 |------------|-------|---------|
 | `contents` | read | Read repository files |
 | `pull-requests` | write | Post review comments |
-| `issues` | write | Required for `gh pr comment` |
+| `issues` | write | Required for `gh pr review` |
 | `id-token` | write | OIDC authentication |
 
 Claude's tool access is restricted to:
 
 - `Read`, `Grep`, `Glob`, `BatchTool` — codebase exploration (read-only)
 - `mcp__github_inline_comment__create_inline_comment` — post inline review comments (built-in MCP tool)
-- `Bash(gh pr comment:*)` — post PR summary comments
+- `Bash(gh pr review:*)` — submit formal PR review with verdict
 - `Bash(gh pr diff:*)` — read PR diff
 - `Bash(gh pr view:*)` — read PR metadata
 - `Bash(gh api:*)` — manage review threads and comments
@@ -253,6 +265,9 @@ jobs:
       id-token: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    # Optional: direct Claude's attention to specific areas
+    # with:
+    #   extra_focus: "check backward compatibility of the API changes"
 ```
 
 ## Configuration
@@ -263,3 +278,4 @@ jobs:
 - **Timeout**: 30 minutes per review
 - **Max turns**: 30
 - **Progress tracking**: `track_progress: true` — shows visual "In progress" → "Completed" status
+- **Extra focus**: Optional `extra_focus` input to direct the review toward specific concerns


### PR DESCRIPTION
## Summary

- **`gh pr review` instead of `gh pr comment`** for the review summary — shows in PR sidebar with a formal verdict instead of being buried in the comment timeline
- **Review verdict logic**: `REQUEST_CHANGES` when issues found with confidence >= 80, `COMMENT` otherwise, never `APPROVE` (avoids silently satisfying branch protection approval requirements)
- **`extra_focus` optional input** — callers can direct Claude's attention to specific areas (e.g. "check backward compatibility of API changes")
- **Tool list updated**: `Bash(gh pr comment:*)` replaced with `Bash(gh pr review:*)`
- **Docs updated** (`docs/claude-code-review.md`)

`workflow_dispatch` secondary trigger (#2 from the issue) is deferred — it requires refactoring the reusable's `github.event.pull_request.*` context handling and is better as a follow-up.

Closes #66

## Test plan

- [x] Pre-commit hooks pass (actionlint, zizmor, detect-secrets)
- [ ] CI passes
- [ ] The claude-code-review run ON THIS PR itself will be the first live test of `gh pr review` — its summary should appear in the Reviews sidebar, not as a comment