### PR TITLE
fix: classify PR-level reviews in shell pre-processing step

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -256,7 +256,7 @@ jobs:
             5b. PR-level reviews: use `human_reviews` from classified-reviews.json.
             For each review with a non-empty `body`, read the review body and
             classify the feedback. PR-level reviews don't have threads to
-            resolve — just acknowledge them in the summary (step 7).
+            resolve — just acknowledge them in the summary (step 8).
             If a review has `state == "CHANGES_REQUESTED"`, treat its feedback
             as high-priority.
 
@@ -264,14 +264,29 @@ jobs:
             Do NOT dismiss human comments as false positives or cosmetic nitpicks.
             If unsure whether an issue is fixed, leave it open.
 
-            6. Post inline comments using `mcp__github_inline_comment__create_inline_comment`
+            6. MANDATORY — Review the PR diff for new issues.
+            This is the core review step. Read each changed file in the diff
+            and analyze the NEW code (+ side) for:
+            - Bugs or logic errors (use-before-assignment, off-by-one, unreachable code)
+            - Security vulnerabilities (SQL injection, XSS, auth bypass, secrets exposure)
+            - Breaking changes not mentioned in the PR description
+            - CLAUDE.md violations (verify the rule exists and quote it)
+            - Missing error handling in new code paths
+            - Missing tests for new functionality
+            - Critical performance issues (N+1 queries, unnecessary allocations in hot paths)
+            For each potential issue, assess confidence 0-100. Only report
+            issues scoring >= 80. Do NOT review unchanged code, style/formatting,
+            optional improvements, or dependency versions.
+
+            7. Post inline comments for issues found in step 6 using
+            `mcp__github_inline_comment__create_inline_comment`
             with `confirmed: true`. Only comment on lines in the diff (NEW version).
             Use `startLine` + `line` for multi-line ranges. Format each comment:
             severity emoji + one-sentence summary + fix suggestion, then a
             collapsible `<details>` block with extended reasoning.
             Emojis: 🔴 bug, 🟠 security, 🟡 risky pattern, 🔵 CLAUDE.md violation.
 
-            7. Submit a formal PR review via `gh pr review` with this structure.
+            8. Submit a formal PR review via `gh pr review` with this structure.
             Choose the review event based on findings:
             - No issues found → `--event COMMENT`
             - Issues found (confidence >= 80) → `--event REQUEST_CHANGES`
@@ -304,14 +319,9 @@ jobs:
             `pr_author_threads` are excluded from all triage sections.
 
             RULES:
-            - Confidence >= 80 to report an issue. False positives waste reviewer time.
-            - For CLAUDE.md violations: verify the rule exists and quote it.
-            - Focus: bugs, security, breaking changes, CLAUDE.md violations, missing
-              error handling, missing tests, critical performance issues.
-            - Ignore: unchanged code, style/formatting, optional improvements,
-              dependency versions. Do NOT run build tools or provide praise.
             - Every API call is permanent. Do NOT post test or placeholder comments.
             - Only post GitHub review submissions — don't submit review text as messages.
+            - Do NOT run build tools or provide praise.
           settings: |
             {
               "permissions": {

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -59,8 +59,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          # Fetch all review threads with author type via GraphQL
-          threads_json=$(gh api graphql -f query="
+          # Fetch review threads AND PR-level reviews via GraphQL
+          pr_json=$(gh api graphql -f query="
             query {
               repository(owner: \"$REPO_OWNER\", name: \"$REPO_NAME\") {
                 pullRequest(number: $PR_NUMBER) {
@@ -79,12 +79,21 @@ jobs:
                       }
                     }
                   }
+                  reviews(first: 50) {
+                    nodes {
+                      id
+                      databaseId
+                      state
+                      body
+                      author { login __typename }
+                    }
+                  }
                 }
               }
             }")
 
-          # Classify each thread deterministically
-          echo "$threads_json" | jq --arg pr_author "$PR_AUTHOR" '
+          # Classify threads deterministically
+          echo "$pr_json" | jq --arg pr_author "$PR_AUTHOR" '
             .data.repository.pullRequest.reviewThreads.nodes | map(
               . as $thread |
               ($thread.comments.nodes[0].author // {login: "unknown", __typename: "User"}) as $author |
@@ -112,6 +121,32 @@ jobs:
               pr_author_threads: [.[] | select(.category == "pr_author")]
             }' > /tmp/classified-threads.json
 
+          # Classify PR-level reviews deterministically (skip PENDING)
+          echo "$pr_json" | jq --arg pr_author "$PR_AUTHOR" '
+            .data.repository.pullRequest.reviews.nodes
+            | map(select(.state != "PENDING"))
+            | map(
+              . as $review |
+              ($review.author // {login: "unknown", __typename: "User"}) as $author |
+              {
+                review_id: $review.id,
+                review_db_id: $review.databaseId,
+                state: $review.state,
+                body: ($review.body // "")[0:200],
+                author_login: $author.login,
+                author_type: $author.__typename,
+                category: (
+                  if $author.__typename == "Bot" then "bot"
+                  elif $author.login == $pr_author then "pr_author"
+                  else "human"
+                  end
+                )
+              }
+            ) | {
+              human_reviews: [.[] | select(.category == "human")],
+              bot_reviews: [.[] | select(.category == "bot")]
+            }' > /tmp/classified-reviews.json
+
           echo "=== Thread classification ==="
           jq '{
             claude: (.claude_threads | length),
@@ -119,6 +154,12 @@ jobs:
             human: (.human_threads | length),
             pr_author: (.pr_author_threads | length)
           }' /tmp/classified-threads.json
+
+          echo "=== Review classification ==="
+          jq '{
+            human: (.human_reviews | length),
+            bot: (.bot_reviews | length)
+          }' /tmp/classified-reviews.json
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1.0.88
@@ -136,9 +177,9 @@ jobs:
             1. Read CLAUDE.md and any files it references to learn project
             conventions and review standards.
 
-            2. Get the PR diff with `gh pr diff`. Read `/tmp/classified-threads.json`
-            which contains ALL review threads pre-classified by a shell step.
-            The JSON has this structure:
+            2. Get the PR diff with `gh pr diff`. Read both classified JSON files:
+
+            `/tmp/classified-threads.json` — inline review threads:
             ```json
             {
               "claude_threads": [...],   // threads authored by claude (Bot)
@@ -149,9 +190,22 @@ jobs:
             ```
             Each thread has: `thread_id`, `is_resolved`, `comment_id`, `path`,
             `line`, `body` (first 200 chars), `author_login`, `author_type`, `category`.
-            Use ONLY this classification — do NOT re-classify threads yourself.
-            Also fetch REST comments (`gh api --paginate .../pulls/NUMBER/comments`)
-            to get `node_id` for minimize mutations. Do NOT re-report already-flagged issues.
+
+            `/tmp/classified-reviews.json` — PR-level reviews (review bodies):
+            ```json
+            {
+              "human_reviews": [...],  // PR-level reviews by human reviewers
+              "bot_reviews": [...]     // PR-level reviews by bots
+            }
+            ```
+            Each review has: `review_id`, `review_db_id`, `state` (APPROVED,
+            CHANGES_REQUESTED, COMMENTED, DISMISSED), `body` (first 200 chars),
+            `author_login`, `author_type`, `category`.
+
+            Use ONLY these classifications — do NOT re-classify threads or
+            reviews yourself. Also fetch REST comments
+            (`gh api --paginate .../pulls/NUMBER/comments`) to get `node_id`
+            for minimize mutations. Do NOT re-report already-flagged issues.
 
             3. MANDATORY — Process ALL previous Claude review threads.
             Use `claude_threads` from the classified JSON.
@@ -184,8 +238,10 @@ jobs:
               `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'`
             Dismiss cosmetic nitpicks — only acknowledge real bugs/security issues.
 
-            5. MANDATORY — Triage human reviewer comments.
-            Use `human_threads` from the classified JSON.
+            5. MANDATORY — Triage human reviewer feedback.
+            This covers BOTH inline threads AND PR-level reviews.
+
+            5a. Inline threads: use `human_threads` from classified-threads.json.
             For each UNRESOLVED thread (`is_resolved == false`), read the
             CURRENT file content and classify:
             - FIXED: reply acknowledging the fix, then resolve:
@@ -196,7 +252,15 @@ jobs:
               — only humans should resolve human feedback.
               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments/COMMENT_ID/replies --method POST -f body="Acknowledged — flagging for the PR author to address."`
             - ALREADY RESOLVED: skip
-            Human reviewer comments are high-signal — treat them with respect.
+
+            5b. PR-level reviews: use `human_reviews` from classified-reviews.json.
+            For each review with a non-empty `body`, read the review body and
+            classify the feedback. PR-level reviews don't have threads to
+            resolve — just acknowledge them in the summary (step 7).
+            If a review has `state == "CHANGES_REQUESTED"`, treat its feedback
+            as high-priority.
+
+            Human reviewer feedback is high-signal — treat it with respect.
             Do NOT dismiss human comments as false positives or cosmetic nitpicks.
             If unsure whether an issue is fixed, leave it open.
 
@@ -223,18 +287,20 @@ jobs:
               with triage of `bot_threads` ONLY, grouped by `author_login`
               (OMIT if `bot_threads` is empty)
             - `<details><summary><h3>Human Review Triage</h3></summary>`
-              with triage of `human_threads` ONLY, grouped by `author_login`.
-              Show each comment's classification (FIXED/VALID) and action taken.
-              (OMIT if `human_threads` is empty)
+              with triage of `human_threads` AND `human_reviews`, grouped by
+              `author_login`. Show each item's classification (FIXED/VALID)
+              and action taken. Separate inline threads from PR-level reviews.
+              (OMIT if both `human_threads` and `human_reviews` are empty)
             - `<details><summary><h3>Important Files Changed</h3></summary>`
               with markdown table (filename | overview)
             Example: `gh pr review ${{ github.event.pull_request.number }} --event COMMENT --body "review body here"`
             CRITICAL: Use ONLY the pre-classified categories from
-            `/tmp/classified-threads.json` for the summary sections. Do NOT
-            re-classify threads or attribute threads to different authors.
+            `/tmp/classified-threads.json` and `/tmp/classified-reviews.json`
+            for the summary sections. Do NOT re-classify threads/reviews or
+            attribute them to different authors.
             `claude_threads` go in step 3 processing only (not in summary sections).
             `bot_threads` go in Bot Review Triage only.
-            `human_threads` go in Human Review Triage only.
+            `human_threads` + `human_reviews` go in Human Review Triage only.
             `pr_author_threads` are excluded from all triage sections.
 
             RULES:

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -43,14 +43,15 @@ flowchart TD
   B -->|Yes| Z(Workflow skipped)
   B -->|No| C(Checkout repository)
   C --> D(Shell: Minimize outdated Claude comments)
-  D --> D2(Shell: Classify review threads)
+  D --> D2(Shell: Classify review threads and PR-level reviews)
   D2 --> E(Step 1: Read CLAUDE.md and project conventions)
-  E --> F(Step 2: Get PR diff + fetch previous comments and threads)
+  E --> F(Step 2: Get PR diff + read classified threads and reviews)
   F --> G(Step 3: Process previous claude bot review threads)
   G --> H(Step 4: Triage bot reviewer comments)
-  H --> I(Step 5: Triage human reviewer comments)
-  I --> J(Step 6: Analyze diff and post inline comments)
-  J --> K(Step 7: Post PR summary comment)
+  H --> I(Step 5: Triage human reviewer comments and PR-level reviews)
+  I --> J(Step 6: Analyze PR diff for new issues)
+  J --> J2(Step 7: Post inline comments)
+  J2 --> K(Step 8: Submit PR review with verdict)
 ```
 
 ### Pre-step A: Minimize Outdated Comments (shell)
@@ -124,9 +125,10 @@ Key differences from bot triage:
 - Valid human comments are **not resolved** by Claude — only humans should resolve human feedback
 - Fixed comments are resolved with a respectful acknowledgment rather than a terse "Fixed" reply
 
-### Step 6: Analyze and Post Inline Comments
+### Step 6: Analyze the PR Diff
 
-Claude reviews each changed line using `mcp__github_inline_comment__create_inline_comment` (built-in MCP tool, no Docker required), focusing on:
+This is the core review step. Claude reads each changed file and analyzes the new code for issues:
+
 
 | Category | Examples |
 |----------|----------|
@@ -163,7 +165,11 @@ Detailed explanation of the issue, proof, impact, and fix.
 | :yellow_circle: | Warning | Likely bug or risky pattern |
 | :large_blue_circle: | Convention | CLAUDE.md violation |
 
-### Step 7: Submit PR Review
+### Step 7: Post Inline Comments
+
+For each issue found in step 6, Claude posts an inline comment using `mcp__github_inline_comment__create_inline_comment` (built-in MCP tool, no Docker required). Comments are anchored to the specific diff lines where the issue occurs.
+
+### Step 8: Submit PR Review
 
 A formal GitHub PR review is submitted via `gh pr review`. This shows in the PR's "Reviews" sidebar (not buried in the comment timeline) and signals a clear verdict.
 
@@ -218,7 +224,8 @@ flowchart TD
   F --> I(Analyze diff for new issues)
   G --> I
   L --> I
-  I --> J(Post updated summary)
+  I --> I2(Post inline comments)
+  I2 --> J(Submit PR review with verdict)
 ```
 
 ## Permissions


### PR DESCRIPTION
## Summary

The shell classification step only fetched `reviewThreads` (inline comments). PR-level reviews (review bodies submitted via "Submit review") were not included in the classified JSON, forcing Claude to discover and classify them via unreliable prompt logic — the same pattern PR #51 was designed to fix.

### Changes

**Shell step** — extend the GraphQL query to also fetch `reviews(first: 50)` and classify them into a separate `/tmp/classified-reviews.json`:
- `human_reviews` — PR-level reviews by human reviewers (`__typename == User`, excluding PR author)
- `bot_reviews` — PR-level reviews by bots (`__typename == Bot`)
- `PENDING` reviews are excluded

**Prompt step 2** — document both classified JSON files and their schemas

**Prompt step 5** — split into:
- 5a: triage inline threads (unchanged logic, uses `human_threads`)
- 5b: triage PR-level reviews (new, uses `human_reviews` — `CHANGES_REQUESTED` reviews are high-priority)

**Prompt step 7** — Human Review Triage section now includes both `human_threads` and `human_reviews`

### Example

A human reviewer submits a PR-level review body like "This approach has an agent bloat problem — too many subagents for simple tasks." Previously, Claude had to discover this via prompt logic and could misclassify the author. Now it's pre-classified in `human_reviews` with correct `author_login` and `state`.

Closes #52

## Test plan

- [x] Pre-commit hooks pass (actionlint, zizmor)
- [ ] CI passes
- [ ] Claude review on this PR itself should read both JSON files and report them in the summary