### PR TITLE
fix: prevent hallucinated findings from leaking into review summary

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -290,11 +290,14 @@ jobs:
             Do NOT fall back to reporting it in the summary (step 8).
 
             8. Submit a formal PR review via `gh pr review` with this structure.
-            Choose the review event based on findings:
-            - No issues found → `--event COMMENT`
-            - Issues found (confidence >= 80) → `--event REQUEST_CHANGES`
-            - NEVER use `--event APPROVE` (auto-approve from a bot can bypass
-              human review gates in branch protection rules)
+            ALWAYS use `--event COMMENT`. NEVER use `REQUEST_CHANGES` or
+            `APPROVE`:
+            - `REQUEST_CHANGES` from a bot creates a merge blocker that
+              only the bot can dismiss — the PR author cannot clear it.
+            - `APPROVE` from a bot can silently satisfy branch protection
+              approval requirements, bypassing human review gates.
+            Severity is communicated through inline comments and the
+            confidence score, not the review event type.
             The review body should contain:
             - `## Claude Code Review Summary` (or `## ✅ No issues found` /
               `## ℹ️ No new issues found — N bot reviewer finding(s) and M human reviewer finding(s) acknowledged`)

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -285,6 +285,9 @@ jobs:
             severity emoji + one-sentence summary + fix suggestion, then a
             collapsible `<details>` block with extended reasoning.
             Emojis: 🔴 bug, 🟠 security, 🟡 risky pattern, 🔵 CLAUDE.md violation.
+            If `mcp__github_inline_comment__create_inline_comment` fails
+            (line not in diff, validation error, etc.), DROP the finding.
+            Do NOT fall back to reporting it in the summary (step 8).
 
             8. Submit a formal PR review via `gh pr review` with this structure.
             Choose the review event based on findings:
@@ -317,8 +320,18 @@ jobs:
             `bot_threads` go in Bot Review Triage only.
             `human_threads` + `human_reviews` go in Human Review Triage only.
             `pr_author_threads` are excluded from all triage sections.
+            The review body MUST contain ONLY these sections: the `##`
+            heading, Confidence Score, Bot Review Triage, Human Review
+            Triage, Important Files Changed. Do NOT add ad-hoc sections
+            describing findings. File/line-level findings belong in
+            inline comments (step 7) ONLY. If an issue cannot be posted
+            as an inline comment, it is not reported.
 
             RULES:
+            - Before reporting that a string is stale or wrong, you MUST
+              `Read` the file and verify the exact claimed text appears on
+              the claimed line. Quote from the Read output verbatim, never
+              from memory. If the text is not in the Read output, drop it.
             - Every API call is permanent. Do NOT post test or placeholder comments.
             - Only post GitHub review submissions — don't submit review text as messages.
             - Do NOT run build tools or provide praise.

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -286,8 +286,10 @@ jobs:
             collapsible `<details>` block with extended reasoning.
             Emojis: 🔴 bug, 🟠 security, 🟡 risky pattern, 🔵 CLAUDE.md violation.
             If `mcp__github_inline_comment__create_inline_comment` fails
-            (line not in diff, validation error, etc.), DROP the finding.
-            Do NOT fall back to reporting it in the summary (step 8).
+            (line not in diff, validation error), include the finding in
+            the step 8 review body under a `### Concept-level observations`
+            section instead. Do NOT claim a specific file:line for these
+            — describe the concern at the design/architecture level only.
 
             8. Submit a formal PR review via `gh pr review` with this structure.
             ALWAYS use `--event COMMENT`. NEVER use `REQUEST_CHANGES` or
@@ -325,10 +327,11 @@ jobs:
             `pr_author_threads` are excluded from all triage sections.
             The review body MUST contain ONLY these sections: the `##`
             heading, Confidence Score, Bot Review Triage, Human Review
-            Triage, Important Files Changed. Do NOT add ad-hoc sections
-            describing findings. File/line-level findings belong in
-            inline comments (step 7) ONLY. If an issue cannot be posted
-            as an inline comment, it is not reported.
+            Triage, Concept-level observations (from step 7 fallbacks
+            only — OMIT if none), Important Files Changed. Do NOT add
+            ad-hoc sections. File/line-level findings belong in inline
+            comments (step 7) ONLY — never narrate line-specific
+            findings in the review body.
 
             RULES:
             - Before reporting that a string is stale or wrong, you MUST

--- a/docs/claude-code-review.md
+++ b/docs/claude-code-review.md
@@ -171,16 +171,14 @@ For each issue found in step 6, Claude posts an inline comment using `mcp__githu
 
 ### Step 8: Submit PR Review
 
-A formal GitHub PR review is submitted via `gh pr review`. This shows in the PR's "Reviews" sidebar (not buried in the comment timeline) and signals a clear verdict.
+A formal GitHub PR review is submitted via `gh pr review`. This shows in the PR's "Reviews" sidebar (not buried in the comment timeline).
 
-**Review verdict:**
+Claude **always** uses `--event COMMENT`. It never uses `REQUEST_CHANGES` or `APPROVE`:
 
-| Scenario | Event |
-|----------|-------|
-| No issues found | `COMMENT` |
-| Issues found (confidence >= 80) | `REQUEST_CHANGES` |
+- **`REQUEST_CHANGES`** from a bot creates a merge blocker that only the bot can dismiss — the PR author cannot clear it.
+- **`APPROVE`** from a bot can silently satisfy branch protection approval requirements, bypassing human review gates.
 
-Claude **never** uses `APPROVE` — auto-approving from a bot can silently satisfy branch protection rules, bypassing human review gates.
+Severity is communicated through inline comments and the confidence score, not the review event type.
 
 The review body heading varies based on findings:
 


### PR DESCRIPTION
## Summary

Three prompt hardening changes to close the path where the model narrates findings in the review summary that were never posted as inline comments — or are outright hallucinations (see #65 for the evidence).

1. **Lock down summary template** (step 8) — only the defined sections are allowed: Confidence Score, Bot/Human Review Triage, Important Files Changed. No ad-hoc findings sections.

2. **Require Read-based quote verification** (RULES) — before reporting a string as stale or wrong, the model MUST `Read` the file and verify the exact text on the claimed line. Quote from output, never from memory.

3. **Drop failed inline comments** (step 7) — if `mcp__github_inline_comment__create_inline_comment` rejects a finding (line not in diff), the finding is dropped entirely instead of falling back to the summary.

Fix (1) alone closes the leak path; (2) and (3) are defense-in-depth.

Closes #65

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Claude review on this PR itself should NOT produce ad-hoc findings sections in the summary