### PR TITLE
feat: add reusable release-please-guard workflow

### DIFF
--- a/.github/workflows/release-please-guard.yml
+++ b/.github/workflows/release-please-guard.yml
@@ -1,0 +1,11 @@
+---
+name: release-please-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: ./.github/workflows/reusable-release-please-guard.yml
+    permissions:
+      contents: read

--- a/.github/workflows/reusable-release-please-guard.yml
+++ b/.github/workflows/reusable-release-please-guard.yml
@@ -30,9 +30,12 @@ jobs:
             echo "Release-please PR from trusted automation — skipping guard."
             exit 0
           fi
-          POM_CONTENT=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
-            --jq '.content' 2>/dev/null) || true
-          if [[ -z "$POM_CONTENT" ]]; then
+          if ! POM_CONTENT=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
+            --jq '.content' 2>/dev/null); then
+            echo "No pom.xml on '$BASE_BRANCH' — skipping guard."
+            exit 0
+          fi
+          if [[ -z "$POM_CONTENT" || "$POM_CONTENT" == "null" ]]; then
             echo "No pom.xml on '$BASE_BRANCH' — skipping guard."
             exit 0
           fi

--- a/.github/workflows/reusable-release-please-guard.yml
+++ b/.github/workflows/reusable-release-please-guard.yml
@@ -1,0 +1,39 @@
+---
+# Blocks PR merges when the base branch pom.xml version is not a *-SNAPSHOT version.
+# This prevents commits from landing after a release and before the snapshot version bump is merged.
+# Setup: add the "release-please-guard" status check as required in branch protection rules
+# and enable "Require branches to be up to date before merging".
+name: release-please-guard (reusable)
+on:
+  workflow_call:
+permissions: {}
+jobs:
+  release-please-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check base branch version is SNAPSHOT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |-
+          set -euo pipefail
+          if [[ "$HEAD_BRANCH" == release-please--* ]]; then
+            echo "Release-please PR — skipping guard."
+            exit 0
+          fi
+          VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
+            --jq '.content' | base64 -d | \
+            awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to extract project version from pom.xml on '$BASE_BRANCH'."
+            exit 1
+          fi
+          if [[ "$VERSION" != *-SNAPSHOT ]]; then
+            echo "::error::Version on '$BASE_BRANCH' is '$VERSION' (not a SNAPSHOT). Merge the release-please snapshot PR first before merging other PRs."
+            exit 1
+          fi
+          echo "Version is '$VERSION'. Good to go."

--- a/.github/workflows/reusable-release-please-guard.yml
+++ b/.github/workflows/reusable-release-please-guard.yml
@@ -19,10 +19,15 @@ jobs:
           GH_REPO: ${{ github.repository }}
           BASE_BRANCH: ${{ github.base_ref }}
           HEAD_BRANCH: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |-
           set -euo pipefail
-          if [[ "$HEAD_BRANCH" == release-please--* ]]; then
-            echo "Release-please PR — skipping guard."
+          if [[ -z "$BASE_BRANCH" ]]; then
+            echo "::error::BASE_BRANCH is empty. This workflow must be called from a pull_request context."
+            exit 1
+          fi
+          if [[ "$HEAD_BRANCH" == release-please--* ]] && [[ "$PR_AUTHOR" == "github-actions[bot]" || "$PR_AUTHOR" == "release-please[bot]" ]]; then
+            echo "Release-please PR from trusted automation — skipping guard."
             exit 0
           fi
           POM_CONTENT=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \

--- a/.github/workflows/reusable-release-please-guard.yml
+++ b/.github/workflows/reusable-release-please-guard.yml
@@ -25,8 +25,13 @@ jobs:
             echo "Release-please PR — skipping guard."
             exit 0
           fi
-          VERSION=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
-            --jq '.content' | base64 -d | \
+          POM_CONTENT=$(gh api "repos/$GH_REPO/contents/pom.xml?ref=$BASE_BRANCH" \
+            --jq '.content' 2>/dev/null) || true
+          if [[ -z "$POM_CONTENT" ]]; then
+            echo "No pom.xml on '$BASE_BRANCH' — skipping guard."
+            exit 0
+          fi
+          VERSION=$(echo "$POM_CONTENT" | base64 -d | \
             awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
           if [[ -z "$VERSION" ]]; then
             echo "::error::Failed to extract project version from pom.xml on '$BASE_BRANCH'."

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository contains **GitHub Actions workflows (reusable and caller/CI)**. 
 | `reusable-pr.yml` | PR checks with conventional commit validation |
 | `reusable-openapi-validation.yml` | OpenAPI spec validation using Redocly CLI |
 | `reusable-release-please.yml` | Automated releases and changelogs using release-please (Maven, Python, Docker, etc.) |
+| `reusable-release-please-guard.yml` | Blocks PR merges when the base branch `pom.xml` version is not a SNAPSHOT (prevents post-release drift) |
 
 ## Usage
 
@@ -109,6 +110,21 @@ jobs:
     with:
       release-type: simple
       include-v-in-tag: false
+```
+
+```yaml
+# Maven release-please guard — blocks merges when base branch pom.xml is not a SNAPSHOT
+# Requires branch protection: add "release-please-guard" as required status check
+# and enable "Require branches to be up to date before merging"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions: {}
+jobs:
+  release-please-guard:
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-release-please-guard.yml@main
+    permissions:
+      contents: read
 ```
 
 Each reusable workflow has a corresponding caller workflow (e.g. `claude-code-review.yml`) that demonstrates how this repository itself uses it.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ch.sbb.polarion</groupId>
+  <artifactId>github-workflows-polarion</artifactId>
+  <version>1.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <description>
+    This repo has no Java code. The pom.xml exists solely so the
+    reusable-release-please-guard workflow can be dogfooded here
+    (it checks the base branch pom.xml version is a SNAPSHOT).
+  </description>
+</project>


### PR DESCRIPTION
## Summary

- Adds `reusable-release-please-guard.yml` — blocks PR merges when the base branch `pom.xml` version is not a `*-SNAPSHOT` version, preventing post-release drift
- Adds `release-please-guard.yml` caller to dogfood it in this repo (expected to fail here — no `pom.xml`)
- Documents in `README.md` with usage example and branch protection setup notes

Extracted from [`open-source-polarion-java-repo-template`](https://github.com/SchweizerischeBundesbahnen/open-source-polarion-java-repo-template/blob/main/.github/workflows/release-please-guard.yml).

Closes #73

## Test plan

- [x] Pre-commit hooks pass (actionlint, zizmor)
- [ ] CI passes (the `release-please-guard` job itself will fail — expected, no `pom.xml` in this repo)
- [ ] After merge, update `open-source-polarion-java-repo-template` to use the reusable