### PR TITLE
feat: add reusable-codeql-java.yml

### DIFF
--- a/.github/workflows/reusable-codeql-java.yml
+++ b/.github/workflows/reusable-codeql-java.yml
@@ -1,0 +1,84 @@
+---
+name: CodeQL Java (reusable)
+on:
+  workflow_call:
+    inputs:
+      java-version:
+        description: Java version
+        required: false
+        type: string
+        default: "21"
+      java-distribution:
+        description: Java distribution (e.g. temurin)
+        required: false
+        type: string
+        default: temurin
+      query-suite:
+        description: CodeQL query suite (security-extended | security-and-quality)
+        required: false
+        type: string
+        default: security-extended
+      settings-xml-path:
+        description: Path to Maven settings.xml relative to repo root
+        required: false
+        type: string
+        default: .mvn/settings.xml
+      build-command:
+        description: |
+          Shell command(s) used to build the Java code so CodeQL can extract it.
+          Defaults to a compile-only Maven build; tests/javadoc/source jars are skipped.
+        required: false
+        type: string
+        default: |
+          mvn --batch-mode -s "${SETTINGS_XML}" clean install \
+            -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+      timeout-minutes:
+        description: Job timeout in minutes
+        required: false
+        type: number
+        default: 20
+    secrets:
+      IO_JFROG_SBB_POLARION_TOKEN:
+        required: true
+permissions: {}
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+      packages: read
+    env:
+      # Same secret-binding pattern as the inline codeql.yml on api-extender.
+      # PR-triggered runs from forks do not receive secrets (GitHub default),
+      # so the trust boundary matches the existing Maven build job.
+      IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}  # zizmor: ignore[secrets-outside-env]
+      SETTINGS_XML: ${{ github.workspace }}/${{ inputs.settings-xml-path }}
+      BUILD_COMMAND: ${{ inputs.build-command }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          queries: ${{ inputs.query-suite }}
+      - name: Build (compile only — no tests, no Sonar)
+        shell: bash
+        run: bash -c "$BUILD_COMMAND"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
+        with:
+          category: /language:java-kotlin

--- a/.github/workflows/reusable-codeql-java.yml
+++ b/.github/workflows/reusable-codeql-java.yml
@@ -26,7 +26,10 @@ on:
       build-command:
         description: |
           Shell command(s) used to build the Java code so CodeQL can extract it.
-          Defaults to a compile-only Maven build; tests/javadoc/source jars are skipped.
+          Defaults to a Maven `clean install` with tests, Javadoc, and source-jar
+          generation skipped. `install` (rather than `compile`) is used so that in
+          multi-module reactors downstream modules can resolve their compiled
+          siblings from the local repo during extraction.
         required: false
         type: string
         default: |
@@ -75,7 +78,7 @@ jobs:
           languages: java-kotlin
           build-mode: manual
           queries: ${{ inputs.query-suite }}
-      - name: Build (compile only — no tests, no Sonar)
+      - name: Build (skip tests, Javadoc, source jars)
         shell: bash
         run: bash -c "$BUILD_COMMAND"
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary

- Adds `reusable-codeql-java.yml` — a reusable CodeQL workflow for Polarion Java extension repos using `build-mode: manual`.
- Inputs cover `java-version`, `java-distribution`, `query-suite`, `settings-xml-path`, `build-command`, `timeout-minutes`. Required secret: `IO_JFROG_SBB_POLARION_TOKEN`.
- `-java` suffix in the filename leaves room for a future `reusable-codeql-python.yml` without ambiguity.

## Why

GitHub's default CodeQL setup uses `build-mode: none` and yields incomplete type information on Polarion Java repos (~84% expressions with known type, below CodeQL's 85% threshold; emits a database-quality warning). Manual mode runs the same compile-only Maven build so CodeQL gets the full classpath. This pattern was validated inline on api-extender (PR #112 there); this PR extracts it as a reusable so the Java template and other extensions can adopt it without duplicating the workflow.

## Implementation notes

- `build-command` is passed via `env: BUILD_COMMAND` and executed with `bash -c "$BUILD_COMMAND"`. Same env-var pattern as `reusable-openapi-validation.yml` to avoid template-injection on caller-controlled multi-line input.
- `IO_JFROG_SBB_POLARION_TOKEN` is bound at job-env level (same pattern as the inline workflow; carries `# zizmor: ignore[secrets-outside-env]`).
- Top-level `permissions: {}`; job-level grants only `contents: read`, `security-events: write`, `actions: read`, `packages: read`.
- All actions SHA-pinned with version comments, `persist-credentials: false`.

## Test plan

- [x] zizmor and actionlint pass locally via pre-commit
- [ ] Once merged, point the Java repo template caller at `@main` (separate PR — closes template #137)
- [ ] Optional follow-up: replace api-extender's inline `codeql.yml` with the thin wrapper; database-quality warning stays absent and finding count unchanged ±1

Implements #75