### PR TITLE
fix(release-please-guard): avoid SIGPIPE from base64 with pipefail

### DIFF
--- a/.github/workflows/reusable-release-please-guard.yml
+++ b/.github/workflows/reusable-release-please-guard.yml
@@ -39,8 +39,12 @@ jobs:
             echo "No pom.xml on '$BASE_BRANCH' — skipping guard."
             exit 0
           fi
-          VERSION=$(echo "$POM_CONTENT" | base64 -d | \
-            awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}')
+          # Decode once into a variable, then awk via here-string.
+          # Avoids SIGPIPE from `base64 -d` after `awk` exits on the first
+          # match (with `pipefail`, the broken pipe propagates and fails the
+          # whole step). See issue #78.
+          POM_DECODED=$(echo "$POM_CONTENT" | base64 -d)
+          VERSION=$(awk '/<parent>/{p=1} /<\/parent>/{p=0;next} !p && /<version>/{gsub(/.*<version>|<\/version>.*/,""); print; exit}' <<<"$POM_DECODED")
           if [[ -z "$VERSION" ]]; then
             echo "::error::Failed to extract project version from pom.xml on '$BASE_BRANCH'."
             exit 1


### PR DESCRIPTION
## Summary

Closes #78.

`reusable-release-please-guard.yml` failed with `base64: write error: Broken pipe` and exit code 1 on a downstream consumer, even though the version on `main` was a valid `*-SNAPSHOT`.

Failed run: https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.generic/actions/runs/25436976077/job/74617467810

## Root cause

```bash
set -euo pipefail
…
VERSION=$(echo "$POM_CONTENT" | base64 -d | \
  awk '… print; exit')
```

`awk` exits on the first `<version>` match. The upstream `base64 -d` is still streaming the rest of the decoded pom.xml, gets SIGPIPE on the next write, and prints `base64: write error: Broken pipe`. Under `pipefail` the broken-pipe exit propagates and fails the whole step — even though `$VERSION` was already captured correctly.

The bug fires deterministically when the decoded `pom.xml` is larger than the pipe buffer; it's masked on small projects where the entire content fits before `awk` exits.

## Fix

Decode once into a variable, then pass via here-string:

```bash
POM_DECODED=$(echo "$POM_CONTENT" | base64 -d)
VERSION=$(awk '…' <<<"$POM_DECODED")
```

`<<<` hands the whole content to `awk` as a single buffered input — no upstream process to SIGPIPE.

## Scope

Only `reusable-release-please-guard.yml` had this pattern (grepped `base64 | awk` across all workflows).

## Test plan

- [ ] CI green
- [ ] Re-run the failing job on the downstream consumer (PR #405 in `ch.sbb.polarion.extension.generic`) after this lands; expect green
- [ ] Sanity-check on a small pom.xml repo (template itself) — should still pass