### PR TITLE
ci: set `--effort high` for Claude review to control xhigh cost

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -354,4 +354,4 @@ jobs:
                 ]
               }
             }
-          claude_args: --max-turns 40 --model opus
+          claude_args: --max-turns 40 --model opus --effort high


### PR DESCRIPTION
## Summary

- Add `--effort high` to `claude_args` in `reusable-claude-code-review.yml`. Single-line change.

Closes #82.

## Why

Claude Code defaults to **`xhigh`** effort on Opus 4.7 as of v2.1.117 ([docs](https://code.claude.com/docs/en/model-config#adjust-effort-level)). The pinned `anthropics/claude-code-action@v1.0.110` bundles Claude Code `2.1.123`, so reviews have been running at `xhigh` implicitly since the May 2 action bump. The [effort docs](https://platform.claude.com/docs/en/build-with-claude/effort) describe `xhigh` as *"Expect meaningfully higher token usage than `high`"* and recommend `high` as the cost-conscious floor for intelligence-sensitive work on Opus 4.7.

Setting `high` explicitly:
- caps the per-review token spend at the documented cost/quality sweet spot,
- reduces per-turn tool-call chattiness (relevant because reviews on busy PRs have been hitting the 40-turn cap — see `pandoc-service` PR #167 runs on 2026-05-25).

`reusable-claude.yml` (interactive `@claude` workflow) has the same `xhigh` default behavior, but I've kept this PR scoped to the review workflow per the issue title. Happy to follow up there if wanted.

## Test plan

- [ ] CI passes (zizmor, actionlint, pre-commit) — already green locally.
- [ ] Trigger the review workflow on a representative downstream PR after merge and compare against the prior `xhigh` baseline:
  - `total_cost_usd` (expect lower)
  - `num_turns` (expect lower or equal)
  - Review output quality: same class of findings surfaced (sanity check, not strict regression).
- [ ] If quality holds and turns drop materially, the `--max-turns 30 → 40` bump from #80 can be revisited later.