### PR TITLE
ci: update pull_request types in workflow configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
       - ready_for_review
     paths-ignore:
       - "**.md"


### PR DESCRIPTION
Removed 'synchronize' type from pull_request events.

## Summary

Describe the change and the reason for it.

## Validation

- [ ] Tests were added or updated where appropriate
- [ ] Documentation was updated where appropriate
- [ ] The change follows the repository coding standards
- [ ] This change does not introduce security concerns (secrets, auth, input validation)
- [ ] I reviewed the checklist issue for any repository-level follow-up tasks

## Related

Link related issues, discussions, or design documents.
