### PR TITLE
fix(renovate): ungroup github-actions and drop soak for claude-code-action

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SchweizerischeBundesbahnen/casc-renovate-preset-polarion"
+  ],
+  "packageRules": [
+    {
+      "description": "Ungroup GitHub Actions so a single fast-releasing action cannot hold the whole group behind the minimumReleaseAge gate",
+      "matchManagers": ["github-actions"],
+      "groupName": null
+    },
+    {
+      "description": "anthropics/claude-code-action releases more often than the 3-day stability gate, so it never matures; track it with no soak so it updates",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["anthropics/claude-code-action"],
+      "minimumReleaseAge": "0 days"
+    }
   ]
 }


### PR DESCRIPTION
## Problem
The github-actions Renovate manager is grouped into one branch (groupName: github-actions in the casc-renovate-preset-polarion preset) with a global minimumReleaseAge of 3 days and internalChecksFilter strict.

anthropics/claude-code-action releases every 1-2 days (sometimes multiple times a day). Renovate always targets the latest release, so its renovate/stability-days check never reaches 3 days and the whole grouped branch stays pending forever - no action update merges. The pin has been stuck at v1.0.110 (2026-05-02) while upstream is at v1.0.155.

Every other action in the group (checkout, setup-python, setup-java, upload-artifact, setup-uv, sonarqube-scan-action) releases only every few weeks, so they clear the 3-day gate fine - claude-code-action is the sole blocker.

## Fix
- Ungroup the github-actions manager (groupName: null) so one fast-moving action cannot hold the rest hostage.
- Set minimumReleaseAge 0 days for anthropics/claude-code-action so it can actually clear the gate.

Repo-local override only; the shared preset is unchanged.