### PR TITLE
fix: register the inline-comment MCP server, and carry findings between rounds

### DIFF
--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -79,7 +79,7 @@ jobs:
                       }
                     }
                   }
-                  reviews(first: 50) {
+                  reviews(first: 100) {
                     nodes {
                       id
                       databaseId
@@ -218,8 +218,22 @@ jobs:
             - STILL PRESENT: leave open, count in summary
             - ALREADY RESOLVED: skip
             Note: use thread `thread_id` for resolveReviewThread, comment `node_id`
-            (from REST) for minimizeComment. You cannot score 5/5 confidence
-            if unresolved issues remain.
+            (from REST) for minimizeComment. Threads left unresolved here are
+            one of the three conditions on the confidence score in step 8.
+
+            3b. MANDATORY — Process your OWN previous PR-level review bodies.
+            Use `bot_reviews` from classified-reviews.json, entries whose
+            `author_login` is `claude`. Their `body` is truncated to 200
+            characters, so read the full text with
+            `gh pr view NUMBER --json reviews --jq '.reviews[] | select(.author.login == "claude") | "\(.commit.oid)\n\(.body)"'`.
+            These carry every finding of every earlier round that could not be
+            posted inline, and no thread exists for them, so this step is the
+            only place they are tracked. For each finding in them, read the
+            CURRENT file content and state whether it is FIXED or STILL OPEN in
+            the step 8 summary. Do NOT re-raise a finding you already made in an
+            earlier round — report it as still open instead, and do NOT raise a
+            new finding about wording you yourself introduced in a previous
+            round's suggested fix without saying so.
 
             4. MANDATORY — Triage bot reviewer comments (Copilot, Greptile, etc.).
             First, if Copilot is enabled, wait for it:
@@ -304,8 +318,14 @@ jobs:
             - `## Claude Code Review Summary` (or `## ✅ No issues found` /
               `## ℹ️ No new issues found — N bot reviewer finding(s) and M human reviewer finding(s) acknowledged`)
             - `<details><summary><h3>Confidence Score: X/5</h3></summary>`
-              with brief assessment (5/5 = simple changes fully understood,
-              3/5 = complex changes needing human judgment)
+              This scores the REVIEW, not the change. Score 5/5 only when all
+              three hold: this round raised no finding that is left open, no
+              thread or prior-round finding from step 3 or 3b is still open,
+              and every claim in the body was verified by a Read, an executed
+              command or a cited source. Otherwise score 4/5 and name in one
+              clause which of the three failed. Score 3/5 or below only where
+              the change needs human judgment you could not supply. Never
+              present the score as a severity signal.
             - `<details><summary><h3>Bot Review Triage</h3></summary>`
               with triage of `bot_threads` ONLY, grouped by `author_login`
               (OMIT if `bot_threads` is empty)
@@ -354,4 +374,12 @@ jobs:
                 ]
               }
             }
-          claude_args: --max-turns 40 --model opus --effort high
+          # --allowedTools is what registers the github_inline_comment MCP server:
+          # install-mcp-server.ts starts it only when the allowed-tools list carries an
+          # mcp__github_inline_comment__ prefix, and in agent mode that list is parsed
+          # from claude_args alone. settings.permissions.allow governs whether a tool may
+          # be called, never whether its server is started, so declaring it there left
+          # every review without inline comments.
+          claude_args: >-
+            --max-turns 40 --model opus --effort high
+            --allowedTools "Read,Grep,Glob,BatchTool,mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -160,6 +160,16 @@ jobs:
             human: (.human_reviews | length),
             bot: (.bot_reviews | length)
           }' /tmp/classified-reviews.json
+
+          # Round number for the escalating reporting bar in the prompt. Counted here
+          # rather than left to the model, which cannot count its own history reliably.
+          # Only claude reviews carrying a body are rounds: a review posted as the
+          # container for inline comments has an empty body and is not a round.
+          review_round=$(jq '[.bot_reviews[]
+            | select(.author_login == "claude" and (.body | length) > 0)] | length + 1' \
+            /tmp/classified-reviews.json)
+          echo "review_round=$review_round" >> "$GITHUB_OUTPUT"
+          echo "=== Review round: $review_round ==="
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c  # v1.0.193
@@ -292,6 +302,25 @@ jobs:
             issues scoring >= 80. Do NOT review unchanged code, style/formatting,
             optional improvements, or dependency versions.
 
+            ROUND DISCIPLINE. This is review round
+            ${{ steps.classify-threads.outputs.review_round }} of this pull
+            request. Every round costs a full job and forces another push, so
+            the bar for raising a finding rises with the count. Apply the band
+            for this round, and name the band you applied in the summary:
+            - Rounds 1-3: report anything meeting the step 6 criteria above.
+            - Rounds 4-6: report ONLY findings that change behaviour — what the
+              code does, or what a reader of an instruction file does. Withhold
+              wording, ordering, phrasing and structure findings however real
+              they are, and list them in ONE line as deliberately withheld.
+            - Rounds 7 and beyond: report ONLY bugs, security issues and
+              breaking changes. State that the round cap is reached and that
+              any remaining concern is now a decision for a human reviewer
+              rather than another round.
+            Before raising a finding about text that a PREVIOUS round of yours
+            asked for, say so explicitly and hold it to this round's band. A
+            round whose findings are all traceable to your own earlier
+            suggestions is a signal to stop, not a reason to continue.
+
             7. Post inline comments for issues found in step 6 using
             `mcp__github_inline_comment__create_inline_comment`
             with `confirmed: true`. Only comment on lines in the diff (NEW version).
@@ -315,7 +344,8 @@ jobs:
             Severity is communicated through inline comments and the
             confidence score, not the review event type.
             The review body should contain:
-            - `## Claude Code Review Summary` (or `## ✅ No issues found` /
+            - `## Claude Code Review Summary — round ${{ steps.classify-threads.outputs.review_round }}`
+              (or `## ✅ No issues found` /
               `## ℹ️ No new issues found — N bot reviewer finding(s) and M human reviewer finding(s) acknowledged`)
             - `<details><summary><h3>Confidence Score: X/5</h3></summary>`
               This scores the completeness of the REVIEW, never the risk of

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -230,7 +230,7 @@ jobs:
             posted inline, and no thread exists for them, so this step is the
             only place they are tracked. For each finding in them, read the
             CURRENT file content and state whether it is FIXED or STILL OPEN in
-            the step 8 summary. Do NOT re-raise a finding you already made in an
+            the step 8 Carried Findings section. Do NOT re-raise a finding you already made in an
             earlier round — report it as still open instead, and do NOT raise a
             new finding about wording you yourself introduced in a previous
             round's suggested fix without saying so.
@@ -318,14 +318,25 @@ jobs:
             - `## Claude Code Review Summary` (or `## ✅ No issues found` /
               `## ℹ️ No new issues found — N bot reviewer finding(s) and M human reviewer finding(s) acknowledged`)
             - `<details><summary><h3>Confidence Score: X/5</h3></summary>`
-              This scores the REVIEW, not the change. Score 5/5 only when all
-              three hold: this round raised no finding that is left open, no
-              thread or prior-round finding from step 3 or 3b is still open,
-              and every claim in the body was verified by a Read, an executed
-              command or a cited source. Otherwise score 4/5 and name in one
-              clause which of the three failed. Score 3/5 or below only where
-              the change needs human judgment you could not supply. Never
-              present the score as a severity signal.
+              This scores the completeness of the REVIEW, never the risk of
+              the change. Take the first rule that applies, in order:
+              3/5 or below where you could not review part of the change at
+              all — a file you could not read, behaviour no available means
+              could settle; name the part.
+              4/5 where any of these holds: this round left a finding open; a
+              thread or prior-round finding from step 3 or 3b is still open; a
+              claim in the body rests on something you could not verify. Name
+              in one clause which.
+              5/5 only where none of the above applies.
+              Never present the score as a severity signal, and never let it
+              stand in for saying what is open.
+            - `<details><summary><h3>Carried Findings</h3></summary>`
+              with the step 3b findings from your own earlier rounds, each
+              marked FIXED or STILL OPEN against the current file content.
+              These are exempt from the no-line-specific-findings rule below:
+              they were raised in an earlier round precisely because no inline
+              comment could be posted, so name their file and line.
+              (OMIT if step 3b found none)
             - `<details><summary><h3>Bot Review Triage</h3></summary>`
               with triage of `bot_threads` ONLY, grouped by `author_login`
               (OMIT if `bot_threads` is empty)
@@ -346,12 +357,12 @@ jobs:
             `human_threads` + `human_reviews` go in Human Review Triage only.
             `pr_author_threads` are excluded from all triage sections.
             The review body MUST contain ONLY these sections: the `##`
-            heading, Confidence Score, Bot Review Triage, Human Review
-            Triage, Concept-level observations (from step 7 fallbacks
-            only — OMIT if none), Important Files Changed. Do NOT add
-            ad-hoc sections. File/line-level findings belong in inline
-            comments (step 7) ONLY — never narrate line-specific
-            findings in the review body.
+            heading, Confidence Score, Carried Findings, Bot Review Triage,
+            Human Review Triage, Concept-level observations (from step 7
+            fallbacks only — OMIT if none), Important Files Changed. Do NOT
+            add ad-hoc sections. File/line-level findings belong in inline
+            comments (step 7) ONLY — never narrate line-specific findings in
+            the review body, with the single exception of Carried Findings.
 
             RULES:
             - Before reporting that a string is stale or wrong, you MUST
@@ -380,6 +391,10 @@ jobs:
           # from claude_args alone. settings.permissions.allow governs whether a tool may
           # be called, never whether its server is started, so declaring it there left
           # every review without inline comments.
+          # INVARIANT: this list and settings.permissions.allow above must stay
+          # identical. A tool in settings only is permitted but its server never
+          # starts; a tool here only starts its server but the call is denied.
+          # Both failures are silent — that split is the bug this comment exists for.
           claude_args: >-
             --max-turns 40 --model opus --effort high
             --allowedTools "Read,Grep,Glob,BatchTool,mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
## The defect

The reviewer has posted no inline comment on four of the last five pull requests in `claude-toolkit-polarion`, and reports `create_inline_comment is not registered` in every round of the two long-running ones.

| Pull request | Inline comments | Rounds reporting the tool missing |
|---|---|---|
| #170 | 0 | — |
| #173 | 0 | — |
| #176 | 0 | 19 of 19 |
| #177 | 0 | 10 of 10 |
| #180 | 3 by `claude[bot]` | 0 |

## The cause

`install-mcp-server.ts` starts the server only when the allowed-tools list carries the right prefix:

```ts
if (isEntityContext(context) && context.isPR &&
    (hasGitHubMcpTools || hasInlineCommentTools)) {
  baseMcpConfig.mcpServers.github_inline_comment = { ... }
}
```

In agent mode — which this workflow is in, since it passes an explicit `prompt` — that list has exactly one source:

```ts
const allowedTools = parseAllowedTools(process.env.CLAUDE_ARGS)
```

`claude_args` was `--max-turns 40 --model opus --effort high`, with no `--allowedTools`. The tool was declared only in `settings.permissions.allow`, which decides whether a tool may be **called** and never whether its server is **started**. The gate therefore never saw it, and the workflow was granting permission for something it had not launched.

## What else this fixes

Three problems follow from the same failure, and are corrected in the same change.

**`bot_reviews` was never consumed.** It is classified at the GraphQL step, counted in the log, described in the prompt, and then used by no step. Where inline commenting is unavailable every finding lives in a pull-request-level body, and those bodies are the only record of it — so nothing was carried between rounds, each round re-derived the change from scratch, and the instruction `Do NOT re-report already-flagged issues` had no data behind it. A new step 3b processes them, and reads the full text rather than the 200-character truncation the classified JSON carries.

**The confidence score was defined twice, incompatibly.** Step 8 gave a complexity scale (`5/5 = simple changes fully understood, 3/5 = complex changes needing human judgment`); step 3 gave a thread-state gate (`You cannot score 5/5 confidence if unresolved issues remain`); neither mentioned verification. Measured over the 26 scored reviews on six pull requests, the score took two values — 23 at 4/5, 3 at 5/5, none below — and the three 5/5 rounds agree on nothing: one was clean and verified, one states inside its own score block that a 403 left CI unverified, and one raised an open finding. A single definition now covers open findings, carried threads and verification, and the score is explicitly not a severity signal.

**`reviews(first: 50)` would have begun dropping the oldest reviews silently.** One pull request already carries 20. Raised to 100.

## Verification

`actionlint` and `zizmor` pass through pre-commit. The folded scalar was parsed back to confirm `claude_args` resolves to a single line carrying the `mcp__github_inline_comment__` prefix, which is what the gate tests.

Registration itself can only be confirmed by a run: the next review on a consuming pull request should post inline comments and stop reporting the tool as unregistered.

## Known gap

#180 received three genuine `claude[bot]` inline comments on 2026-08-15 under the same workflow file, the same action version and the same empty `claude_args`, so on that run the server was registered. The action version was ruled out (#176 also failed on `v1.0.193`), as were the workflow file and the inputs, which are byte-identical in both job logs. The likeliest remaining explanation is that the action resolved a different mode on that run, since the tag-mode path builds its tool list from `tagModeTools` rather than from `claude_args`, but this was not confirmed.

This does not affect the fix. Declaring the tool in `claude_args` satisfies the gate directly, which makes registration deterministic rather than dependent on whichever path produced the one working run.


## Round cap (`1b6bd9b`)

Nothing bounded the number of review rounds. Measured over `claude-toolkit-polarion`:

| Pull request | Review bodies | Rounds | Inline |
|---|---|---|---|
| #176 | 183,912 chars | 20 | 0 |
| #177 | 59,318 | 10 | 0 |
| #170 | 32,651 | 7 | 0 |
| #180 | 7,182 | 3 | 4,062 |

Total volume is round count multiplied by per-round size, and only the first factor was unbounded. Note the last row: where inline commenting worked, one pull request cost 11,244 characters in total. Where it did not, another cost 183,912 — so the register fix above is also the larger part of the readability problem.

The round number is computed in the classification step rather than left to the model, which cannot count its own history reliably. Only reviews carrying a body count, because a review posted as the container for inline comments has an empty body and is not a round. Verified against live data: this pull request computes round 2, where the unfiltered count would say 5, and the 20-round pull request computes 21.

The reporting bar then rises with the count:

- **Rounds 1 to 3** — unchanged.
- **Rounds 4 to 6** — only findings that change behaviour, meaning what the code does or what a reader of an instruction file does. Wording, ordering and structure findings are withheld and listed in one line.
- **Rounds 7 and beyond** — only bugs, security issues and breaking changes, with an explicit statement that any remaining concern is a decision for a human reviewer rather than another round.

A finding about text that an earlier round asked for must now be declared as such and held to the current band. That is the self-inflicted case which produced two consecutive rounds on the pull request that prompted this work.

The round number also appears in the summary heading, so the length of a loop is visible without counting reviews. The `Minimize outdated Claude comments` step matches the heading with `test()`, so the suffix does not break it.
