### PR TITLE
fix: re-review on push, scope pre-review state claims, and set effort on the interactive workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
       - ready_for_review
+      - reopened
     paths-ignore:
       - "**.md"
       - "**.txt"

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -14,10 +14,17 @@ on:
 permissions: {}
 jobs:
   claude-review:
-    # Skip Claude review for bot PRs and fork PRs
+    # Skip Claude review for bot PRs, fork PRs and drafts.
+    #
+    # Drafts are skipped because callers subscribe to `synchronize`, so every
+    # push to a work-in-progress branch would otherwise cost a full review.
+    # The `ready_for_review` trigger already encodes the intent that a draft
+    # waits: the review runs once the pull request is marked ready, and on
+    # every push after that.
     if: |
       !contains(github.event.pull_request.user.login, '[bot]') &&
-      github.event.pull_request.head.repo.fork == false
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       actions: read  # Required for claude-code-action github_ci MCP server
@@ -395,6 +402,17 @@ jobs:
             the review body, with the single exception of Carried Findings.
 
             RULES:
+            - Every read of this pull request's own review state is taken
+              BEFORE your review is posted and therefore does not count it.
+              This applies to how many reviews name a commit, which commit
+              the newest review body names, and how many threads are
+              unresolved. A maintainer who re-runs the query after your
+              review lands gets a different answer, so never present such a
+              value as the reader's current state: either scope it in time
+              ("before this review, no body named HEAD") or add this review
+              to the count. Never let such a value be the only evidence for
+              a finding — the finding may be right while the evidence given
+              for it is already false when it is read.
             - Before reporting that a string is stale or wrong, you MUST
               `Read` the file and verify the exact claimed text appears on
               the claimed line. Quote from the Read output verbatim, never

--- a/.github/workflows/reusable-claude.yml
+++ b/.github/workflows/reusable-claude.yml
@@ -46,4 +46,4 @@ jobs:
           track_progress: true
           additional_permissions: |
             actions: read
-          claude_args: --max-turns 30 --model opus
+          claude_args: --max-turns 30 --model opus --effort high


### PR DESCRIPTION
## Summary

Closes three defects in the Claude review workflows. All three are one-line or one-block changes; #90 is deliberately left out and explained below.

### #89 — the review never re-ran after a pull request was opened

`claude-code-review.yml` subscribed to `opened` and `ready_for_review` only, so the review ran once against the state a pull request had when it was opened and never again. Every later commit — including the commits pushed to address the review — reached `main` unreviewed, and nothing on the pull request surface indicated the review was stale. Verified on #88: four commits, one review run, against the first.

`synchronize` and `reopened` are added, matching the caller in the consumer repository where the identical defect was fixed on 2026-08-06. The existing concurrency group with `cancel-in-progress: true` already prevents overlapping runs on rapid pushes.

**Beyond the literal issue:** because `synchronize` makes every push cost a full review, drafts are now skipped in the reusable workflow (`github.event.pull_request.draft == false`). The `ready_for_review` trigger already encodes the intent that a work-in-progress branch waits; without the guard, adding `synchronize` would review every intermediate commit of a draft. This is a behaviour change for downstream callers that today receive a review when a draft is opened.

### #87 — findings cited the job's own blind spot as current state

The job reads the pull request's review state during its own run, before its review is posted, and reported what it saw as the reader's state. Findings were argued from a review count or a "the newest body names X" that was already false by the time a maintainer read them — the underlying defects were real, the evidence given for them was not.

A rule is added to the prompt's closing `RULES:` block requiring any such value to be scoped in time ("before this review, no body named HEAD") or to count the review being written, and forbidding it as the sole evidence for a finding.

### #81 — `--effort high` on the interactive workflow

The last open follow-up from the max-turns post-mortem. `reusable-claude-code-review.yml` received `--effort high` in 2026-05 (cost roughly $2 to $0.65 a run, turns 27-33 to 12); `reusable-claude.yml` was left on the implicit `xhigh` default. Mirrored here. The post-mortem's second follow-up — observing a few fresh review runs — is settled by the runs since.

## Not included: #90

#90 asks to replace the `github_inline_comment` MCP server with a batched `POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews` call. It is framed by its own author as an evaluation rather than a defect, and it carries a failure mode the three changes above do not: the REST call is all-or-nothing, so a single invalid `line` returns 422 and posts no review at all, where the MCP path degrades one comment at a time. Bundling an unproven mechanism swap with three small fixes risks taking down the whole reviewer on a bad round.

A constraint not recorded in #90 has been added there as a comment: the agent's `--allowedTools` carries no `Write` or `Edit` tool, so the batched JSON payload can only be constructed as a heredoc on the `gh api` line itself. This narrows how the prototype can be written and is worth settling before the switch is attempted.

## Verification

`pre-commit` (including `zizmor` and `actionlint`) passes on all three files, and all 12 checks on `b903406` are green.

**Correction to an earlier revision of this description.** It claimed this pull request exercises its own fix, on the grounds that `pull_request` events read the workflow definition from the head branch. That is wrong, and the review on this branch did not run.

`claude-code-action` refuses to start when the triggering workflow file differs from the version on the default branch. Run `32273783450` records it:

```
Attempt 1 failed: Workflow validation failed. The workflow file must exist and have
identical content to the version on the repository's default branch.
Error is not retryable, giving up immediately
##[warning]Skipping action due to workflow validation
```

At the pinned SHA, `src/github/token.ts` throws `WorkflowValidationSkipError` when the OIDC token exchange returns a workflow-validation error code, and the retry wrapper excludes that error from retry. The step then completes successfully, so the job is green and no review is posted — the failure is silent on the pull request surface. The guard is a supply-chain control: a pull request able to edit the review workflow could otherwise rewrite it to exfiltrate the OAuth token.

The guard covers the **triggering caller** workflow, not the reusable workflow it calls. #88 changed `reusable-claude-code-review.yml` alone and received a full review with no validation warning; this pull request also changes `claude-code-review.yml`, and is refused.

So the trigger change cannot be demonstrated on the branch that carries it. It takes effect once merged, and the first pull request opened after the merge is where `synchronize` can be observed. Reviewers should read the three changes on their merits rather than expecting a bot review on this pull request.
