### PR TITLE
ci: assert claude-code-action tool lists stay identical

### DIFF
--- a/.github/scripts/check_tool_list_parity.py
+++ b/.github/scripts/check_tool_list_parity.py
@@ -91,6 +91,25 @@ def check_step(path: str, job: str, index: int, step: dict) -> list[str]:
     with_ = step.get("with") or {}
     settings, claude_args = with_.get("settings"), with_.get("claude_args")
 
+    # A ${{ }} expression is resolved by the runner, so its value is not in the
+    # file. Neither list can be read, and reporting the expression text as a
+    # divergence would attach a runtime claim to something never parsed. Say the
+    # step went unchecked instead, on stderr, so the gap stays visible: silently
+    # returning would let an expression remove a step from coverage, which is
+    # the failure this script exists to prevent.
+    unresolved = [
+        name
+        for name, value in (("settings", settings), ("claude_args", claude_args))
+        if isinstance(value, str) and "${{" in value
+    ]
+    if unresolved:
+        print(
+            f"{where}: not checked, {' and '.join(unresolved)} is a GitHub "
+            f"expression resolved at run time",
+            file=sys.stderr,
+        )
+        return []
+
     try:
         from_settings = None if settings is None else parse_settings_allow(settings)
     except (json.JSONDecodeError, OSError, TypeError) as exc:

--- a/.github/scripts/check_tool_list_parity.py
+++ b/.github/scripts/check_tool_list_parity.py
@@ -81,16 +81,26 @@ def parse_settings_allow(settings: object) -> set[str] | None:
     if not text.lstrip().startswith("{"):
         with open(text.strip(), encoding="utf-8") as handle:
             text = handle.read()
-    allow = json.loads(text).get("permissions", {}).get("allow")
-    if allow is not None and not isinstance(allow, list):
-        # set() over a str yields its characters. A non-list allow would become a
-        # set of single letters, none of which start with mcp__, so the
-        # settings-only branch below would find no servers and pass — a silent
-        # pass on exactly the configuration this script exists to catch. Reject
-        # it: permissions.allow is a JSON array, so anything else is malformed
-        # input worth naming rather than coercing.
-        raise TypeError(f"permissions.allow is {type(allow).__name__}, not a list")
-    return None if allow is None else set(allow)
+    document = json.loads(text)
+    permissions = document.get("permissions", {}) if isinstance(document, dict) else None
+    if not isinstance(permissions, dict):
+        # A settings *file* may hold any JSON document, and permissions may be
+        # written as something other than a mapping. .get() on either raises
+        # AttributeError, which no handler here catches, so the run would end on
+        # a traceback naming this line instead of the workflow, job and step.
+        raise TypeError("settings has no permissions mapping")
+    allow = permissions.get("allow")
+    if allow is None:
+        return None
+    # set() over a str yields its characters, and a non-str entry has no
+    # .startswith, so the settings-only branch below would either find no mcp__
+    # server and pass — a silent pass on exactly the configuration this script
+    # exists to catch — or raise AttributeError outside any handler.
+    # permissions.allow is a JSON array of strings; anything else is malformed
+    # input worth naming rather than coercing.
+    if not isinstance(allow, list) or not all(isinstance(t, str) for t in allow):
+        raise TypeError(f"permissions.allow is not a list of strings: {allow!r}")
+    return set(allow)
 
 
 def check_step(path: str, job: str, index: int, step: dict) -> list[str]:

--- a/.github/scripts/check_tool_list_parity.py
+++ b/.github/scripts/check_tool_list_parity.py
@@ -82,6 +82,14 @@ def parse_settings_allow(settings: object) -> set[str] | None:
         with open(text.strip(), encoding="utf-8") as handle:
             text = handle.read()
     allow = json.loads(text).get("permissions", {}).get("allow")
+    if allow is not None and not isinstance(allow, list):
+        # set() over a str yields its characters. A non-list allow would become a
+        # set of single letters, none of which start with mcp__, so the
+        # settings-only branch below would find no servers and pass — a silent
+        # pass on exactly the configuration this script exists to catch. Reject
+        # it: permissions.allow is a JSON array, so anything else is malformed
+        # input worth naming rather than coercing.
+        raise TypeError(f"permissions.allow is {type(allow).__name__}, not a list")
     return None if allow is None else set(allow)
 
 

--- a/.github/scripts/check_tool_list_parity.py
+++ b/.github/scripts/check_tool_list_parity.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Assert that a claude-code-action step declares one tool list, not two.
+
+The action reads the agent's tool list from two places that mean different
+things. ``settings.permissions.allow`` governs whether a call is permitted.
+``claude_args --allowedTools`` governs whether an MCP server is started, because
+``install-mcp-server.ts`` starts a server only when the allowed-tools list
+carries its ``mcp__<server>__`` prefix, and in agent mode that list is parsed
+from ``claude_args`` alone.
+
+A tool present in only one list therefore fails silently, in one of two
+directions: declared in ``settings`` alone it is permitted but its server never
+starts, and declared in ``claude_args`` alone its server starts but every call
+is denied. Neither produces an error, a warning, or any signal on the pull
+request. That is the defect this script exists to make loud.
+
+Usage:
+    check_tool_list_parity.py <workflow.yml> [<workflow.yml> ...]
+
+Exits 0 when every claude-code-action step in every file agrees with itself,
+1 on any divergence, and 2 when a file cannot be read or parsed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+import yaml
+
+ACTION = "anthropics/claude-code-action"
+
+# Matches --allowedTools followed by its value, quoted or bare. claude_args is a
+# folded scalar, so the value arrives on one line by the time it is read here.
+ALLOWED_TOOLS = re.compile(
+    r"--allowedTools[=\s]+(?:\"([^\"]*)\"|'([^']*)'|(\S+))"
+)
+
+
+def parse_allowed_tools(claude_args: str) -> set[str] | None:
+    """Return the --allowedTools entries, or None when the flag is absent."""
+    match = ALLOWED_TOOLS.search(claude_args)
+    if match is None:
+        return None
+    value = next(group for group in match.groups() if group is not None)
+    # No tool name contains a comma: the argument syntax has no way to escape
+    # one, so a comma is unambiguously a separator.
+    return {entry.strip() for entry in value.split(",") if entry.strip()}
+
+
+def parse_settings_allow(settings: str) -> set[str] | None:
+    """Return settings.permissions.allow, or None when the block omits it."""
+    allow = json.loads(settings).get("permissions", {}).get("allow")
+    return None if allow is None else set(allow)
+
+
+def check_step(path: str, job: str, index: int, step: dict) -> list[str]:
+    """Return one message per divergence found in a single action step."""
+    where = f"{path}: job '{job}', step {index}"
+    with_ = step.get("with") or {}
+    settings, claude_args = with_.get("settings"), with_.get("claude_args")
+
+    try:
+        from_settings = None if settings is None else parse_settings_allow(settings)
+    except (json.JSONDecodeError, AttributeError) as exc:
+        return [f"{where}: settings is not valid JSON ({exc})"]
+    from_args = None if claude_args is None else parse_allowed_tools(str(claude_args))
+
+    if from_settings is None:
+        if from_args is None:
+            # The step relies on the action's defaults for both. Nothing to
+            # compare, and nothing can diverge.
+            return []
+        return [
+            f"{where}: --allowedTools declares {sorted(from_args)} but there is no "
+            f"settings.permissions.allow, so every call is denied"
+        ]
+    if from_args is None:
+        servers = sorted(t for t in from_settings if t.startswith("mcp__"))
+        if not servers:
+            return []
+        return [
+            f"{where}: settings.permissions.allow declares {servers} but there is no "
+            f"--allowedTools, so those MCP servers never start"
+        ]
+
+    messages = []
+    if settings_only := sorted(from_settings - from_args):
+        messages.append(
+            f"{where}: in settings.permissions.allow but not --allowedTools: "
+            f"{settings_only} — permitted, but any MCP server among them never starts"
+        )
+    if args_only := sorted(from_args - from_settings):
+        messages.append(
+            f"{where}: in --allowedTools but not settings.permissions.allow: "
+            f"{args_only} — the server starts, but every call is denied"
+        )
+    return messages
+
+
+def check_file(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as handle:
+        workflow = yaml.safe_load(handle)
+
+    messages = []
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for index, step in enumerate(job.get("steps") or [], start=1):
+            if isinstance(step, dict) and str(step.get("uses", "")).startswith(ACTION):
+                messages.extend(check_step(path, job_name, index, step))
+    return messages
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(f"usage: {sys.argv[0]} <workflow.yml> [...]", file=sys.stderr)
+        return 2
+
+    messages = []
+    for path in argv:
+        try:
+            messages.extend(check_file(path))
+        except (OSError, yaml.YAMLError) as exc:
+            print(f"{path}: cannot be read ({exc})", file=sys.stderr)
+            return 2
+
+    for message in messages:
+        print(message, file=sys.stderr)
+    if messages:
+        print(
+            "\nThe two lists must hold the same tools. See the INVARIANT comment "
+            "above claude_args in the affected workflow.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/check_tool_list_parity.py
+++ b/.github/scripts/check_tool_list_parity.py
@@ -8,11 +8,16 @@ things. ``settings.permissions.allow`` governs whether a call is permitted.
 carries its ``mcp__<server>__`` prefix, and in agent mode that list is parsed
 from ``claude_args`` alone.
 
-A tool present in only one list therefore fails silently, in one of two
-directions: declared in ``settings`` alone it is permitted but its server never
-starts, and declared in ``claude_args`` alone its server starts but every call
-is denied. Neither produces an error, a warning, or any signal on the pull
-request. That is the defect this script exists to make loud.
+A tool declared in ``settings`` alone is therefore permitted but unavailable:
+its server never starts, and nothing reports it. That is the defect this script
+exists to make loud.
+
+The reverse is not symmetrical. ``base-action/src/parse-sdk-options.ts`` merges
+both flag spellings and passes the result to the SDK as ``allowedTools``, its
+permission allowlist, so a tool declared in ``claude_args`` alone is both
+started and permitted. Where both lists exist they are still required to agree,
+because a reader cannot tell which one is authoritative, but a step declaring
+only ``claude_args`` is the single-list state and passes.
 
 Usage:
     check_tool_list_parity.py <workflow.yml> [<workflow.yml> ...]
@@ -24,34 +29,59 @@ Exits 0 when every claude-code-action step in every file agrees with itself,
 from __future__ import annotations
 
 import json
-import re
+import shlex
 import sys
 
 import yaml
 
 ACTION = "anthropics/claude-code-action"
 
-# Matches --allowedTools followed by its value, quoted or bare. claude_args is a
-# folded scalar, so the value arrives on one line by the time it is read here.
-ALLOWED_TOOLS = re.compile(
-    r"--allowedTools[=\s]+(?:\"([^\"]*)\"|'([^']*)'|(\S+))"
-)
+# Mirrors parseAllowedTools in the action's src/modes/agent/parse-tools.ts: both
+# flag spellings, every occurrence merged, all consecutive non-flag values
+# consumed, comment lines stripped. The action compares the flag token exactly
+# (`flag = arg.slice(2)`), so `--allowedTools=X` is not recognised there and must
+# not be recognised here — treating it as a declaration is what would let a
+# config that grants nothing pass this check.
+ALLOWED_TOOLS_FLAGS = ("--allowedTools", "--allowed-tools")
 
 
 def parse_allowed_tools(claude_args: str) -> set[str] | None:
     """Return the --allowedTools entries, or None when the flag is absent."""
-    match = ALLOWED_TOOLS.search(claude_args)
-    if match is None:
-        return None
-    value = next(group for group in match.groups() if group is not None)
-    # No tool name contains a comma: the argument syntax has no way to escape
-    # one, so a comma is unambiguously a separator.
-    return {entry.strip() for entry in value.split(",") if entry.strip()}
+    tokens = shlex.split(
+        "\n".join(
+            line for line in claude_args.splitlines() if not line.strip().startswith("#")
+        )
+    )
+    tools: set[str] = set()
+    seen_flag = False
+    index = 0
+    while index < len(tokens):
+        if tokens[index] not in ALLOWED_TOOLS_FLAGS:
+            index += 1
+            continue
+        seen_flag = True
+        index += 1
+        while index < len(tokens) and not tokens[index].startswith("--"):
+            # No tool name contains a comma: the argument syntax has no way to
+            # escape one, so a comma is unambiguously a separator.
+            tools.update(e.strip() for e in tokens[index].split(",") if e.strip())
+            index += 1
+    return tools if seen_flag else None
 
 
-def parse_settings_allow(settings: str) -> set[str] | None:
-    """Return settings.permissions.allow, or None when the block omits it."""
-    allow = json.loads(settings).get("permissions", {}).get("allow")
+def parse_settings_allow(settings: object) -> set[str] | None:
+    """Return settings.permissions.allow, or None when the block omits it.
+
+    The action accepts the input as a JSON string or as a path to a JSON file
+    (action.yml: "Claude Code settings as JSON string or path to settings JSON
+    file"), and JSON is valid YAML so the inline form can also arrive already
+    parsed as a mapping. All three are resolved here.
+    """
+    text = settings if isinstance(settings, str) else json.dumps(settings)
+    if not text.lstrip().startswith("{"):
+        with open(text.strip(), encoding="utf-8") as handle:
+            text = handle.read()
+    allow = json.loads(text).get("permissions", {}).get("allow")
     return None if allow is None else set(allow)
 
 
@@ -63,19 +93,19 @@ def check_step(path: str, job: str, index: int, step: dict) -> list[str]:
 
     try:
         from_settings = None if settings is None else parse_settings_allow(settings)
-    except (json.JSONDecodeError, AttributeError) as exc:
-        return [f"{where}: settings is not valid JSON ({exc})"]
-    from_args = None if claude_args is None else parse_allowed_tools(str(claude_args))
+    except (json.JSONDecodeError, OSError, TypeError) as exc:
+        return [f"{where}: settings cannot be read as JSON ({exc})"]
+    try:
+        from_args = None if claude_args is None else parse_allowed_tools(str(claude_args))
+    except ValueError as exc:
+        return [f"{where}: claude_args cannot be tokenized ({exc})"]
 
     if from_settings is None:
-        if from_args is None:
-            # The step relies on the action's defaults for both. Nothing to
-            # compare, and nothing can diverge.
-            return []
-        return [
-            f"{where}: --allowedTools declares {sorted(from_args)} but there is no "
-            f"settings.permissions.allow, so every call is denied"
-        ]
+        # Either the step declares no tool list at all, or it declares only
+        # claude_args. The second is the single-list state: --allowedTools is
+        # itself the SDK's permission allowlist and also decides which MCP
+        # servers start, so there is no second list to diverge from.
+        return []
     if from_args is None:
         servers = sorted(t for t in from_settings if t.startswith("mcp__"))
         if not servers:
@@ -94,7 +124,8 @@ def check_step(path: str, job: str, index: int, step: dict) -> list[str]:
     if args_only := sorted(from_args - from_settings):
         messages.append(
             f"{where}: in --allowedTools but not settings.permissions.allow: "
-            f"{args_only} — the server starts, but every call is denied"
+            f"{args_only} — permitted and started, but the step declares two "
+            f"lists and a reader cannot tell which is authoritative"
         )
     return messages
 

--- a/.github/workflows/reusable-claude-code-review.yml
+++ b/.github/workflows/reusable-claude-code-review.yml
@@ -440,9 +440,12 @@ jobs:
           # be called, never whether its server is started, so declaring it there left
           # every review without inline comments.
           # INVARIANT: this list and settings.permissions.allow above must stay
-          # identical. A tool in settings only is permitted but its server never
-          # starts; a tool here only starts its server but the call is denied.
-          # Both failures are silent — that split is the bug this comment exists for.
+          # identical, asserted by .github/scripts/check_tool_list_parity.py. A tool
+          # in settings only is permitted but its server never starts, silently —
+          # that is the bug this comment exists for. The reverse is not symmetrical:
+          # parse-sdk-options.ts passes this list to the SDK as allowedTools, its
+          # permission allowlist, so a tool here only is both started and permitted.
+          # They are kept identical so a reader can tell which list is authoritative.
           claude_args: >-
             --max-turns 40 --model opus --effort high
             --allowedTools "Read,Grep,Glob,BatchTool,mcp__github_inline_comment__create_inline_comment,Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"

--- a/.github/workflows/tool-list-parity.yml
+++ b/.github/workflows/tool-list-parity.yml
@@ -1,0 +1,29 @@
+---
+name: Tool list parity
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/scripts/check_tool_list_parity.py
+  workflow_dispatch:
+permissions: {}
+jobs:
+  tool-list-parity:
+    name: Assert claude-code-action tool lists agree
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.x"
+      - run: pip install pyyaml
+      # Fails when a tool is declared in settings.permissions.allow but not in
+      # claude_args --allowedTools, or the reverse. Both directions fail
+      # silently at runtime, which is why they are asserted here.
+      - run: python .github/scripts/check_tool_list_parity.py .github/workflows/*.yml

--- a/.github/workflows/tool-list-parity.yml
+++ b/.github/workflows/tool-list-parity.yml
@@ -24,6 +24,14 @@ jobs:
           python-version: "3.x"
       - run: pip install pyyaml
       # Fails when a tool is declared in settings.permissions.allow but not in
-      # claude_args --allowedTools, or the reverse. Both directions fail
-      # silently at runtime, which is why they are asserted here.
-      - run: python .github/scripts/check_tool_list_parity.py .github/workflows/*.yml
+      # claude_args --allowedTools, or the reverse. The first direction fails
+      # silently at runtime, which is why it is asserted here.
+      #
+      # nullglob so an unmatched *.yaml is dropped rather than passed through as
+      # a literal filename. Both extensions, matching the pre-commit hook's
+      # ^\.github/workflows/.*\.ya?ml$ — CI is the binding gate, so it must not
+      # check less than the advisory hook does.
+      - run: |
+          shopt -s nullglob
+          workflows=(.github/workflows/*.yml .github/workflows/*.yaml)
+          python .github/scripts/check_tool_list_parity.py "${workflows[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,11 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: claude-tool-list-parity
+        name: Assert claude-code-action tool lists agree
+        entry: .github/scripts/check_tool_list_parity.py
+        language: python
+        additional_dependencies: [pyyaml]
+        files: ^\.github/workflows/.*\.ya?ml$


### PR DESCRIPTION
Closes #92.

`reusable-claude-code-review.yml` declares the agent's tool list twice, and the two mean different things: `settings.permissions.allow` decides whether a call is **permitted**, while `claude_args --allowedTools` decides whether an MCP **server is started** — `install-mcp-server.ts` starts one only when the allowed-tools list carries its `mcp__<server>__` prefix, and in agent mode that list is parsed from `claude_args` alone.

The two directions are not symmetrical, which an earlier revision of this description got wrong and the review corrected:

| Declared in | Result |
|---|---|
| `settings` only | permitted, but the MCP server never starts — silent, and the defect #88 repaired |
| `claude_args` only | both started and permitted; `parse-sdk-options.ts:319` passes the merged list to the SDK as `allowedTools`, its permission allowlist |

Only the first is a failure. It went unnoticed across four pull requests — every review in that window posted no inline comments and reported success. The two lists are nonetheless required to agree wherever both exist, for the reason that survives: a reader cannot otherwise tell which one is authoritative.

#88 left an `INVARIANT` comment stating the rule, and stating the wrong reason for the second direction. That records it for whoever happens to read the right lines while editing, which is exactly the reader who does not need it: an edit touching one list and not the other still passes `actionlint`, `zizmor` and every other check.

## What this adds

- `.github/scripts/check_tool_list_parity.py` — parses both lists out of every `anthropics/claude-code-action` step and reports the symmetric difference. Its `--allowedTools` parser mirrors `parseAllowedTools` in the action's `src/modes/agent/parse-tools.ts`: both flag spellings, every occurrence merged, all consecutive non-flag values consumed, comment lines stripped, and `--allowedTools=X` deliberately **not** recognised, because the action compares the flag token exactly and that form declares nothing there. It resolves all three documented `settings` forms — inline JSON, a YAML mapping, and a path to a JSON file.
- `.github/workflows/tool-list-parity.yml` — runs it on pull requests touching `.github/workflows/**` or the script.
- A `pre-commit` local hook on the same paths, so a divergence fails before the commit rather than after the push.
- The corrected `INVARIANT` comment, now pointing at the check that enforces it.

## Verification

| Case | Expected | Actual |
|---|---|---|
| Real `.github/workflows/*.yml` | 0 | 0 |
| MCP tool removed from `--allowedTools` only | 1 | 1 |
| MCP tool removed from `settings` only | 1 | 1 |
| `--allowedTools` removed entirely | 1 | 1 |
| `--allowedTools=` form (declares nothing to the action) | 1 | 1 |
| Hyphenated `--allowed-tools` spelling | 0 | 0 |
| Unreadable file | 2 | 2 |

Seven parser cases verified directly against `parse_allowed_tools`, covering both spellings, the `=` form, repeated flags, multiple consecutive values, comment stripping and flag absence. Full `pre-commit` run passes with the new hook.


## Review outcome

Five rounds, seven findings, all fixed and all threads resolved. Every finding was verified against its own source before being accepted — the pinned action at `459ad358ae43fea66bfefd0a1f8d840b4b9791fb` for the parser and permission claims, `action.yml` for the `settings` input, and reproduction for the two crash and silent-pass classes. Round 5 raised nothing new.

Two hardening observations were deliberately withheld by the review under its round 4-6 band and are left for a human reviewer rather than a further round. Both fail loudly rather than passing silently, and neither trigger exists in this repository today:

- A checked file that parses to something other than a mapping — empty, or comment-only — reaches an unhandled `AttributeError`.
- The `${{ }}` guard takes a whole step out of scope when an expression appears anywhere in `claude_args`, not only where it stands in for a tool list. This is the stated trade-off accepted in round 2: the guarantee covers steps that declare their lists literally.

Two documentation-wording observations were also withheld and are worth correcting whenever this file is next touched: the description above does not mention that the workflow also triggers on `push` to `main` and on `workflow_dispatch`, and the script docstring's exit-code contract predates the settings-file case.
